### PR TITLE
Add Parsec copyright on all files

### DIFF
--- a/cryptoki-sys/build.rs
+++ b/cryptoki-sys/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 fn main() {
     #[cfg(feature = "generate-bindings")]
     {

--- a/cryptoki-sys/src/lib.rs
+++ b/cryptoki-sys/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/cryptoki/src/functions/decryption.rs
+++ b/cryptoki/src/functions/decryption.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Decrypting data
 
 use crate::get_pkcs11;

--- a/cryptoki/src/functions/encryption.rs
+++ b/cryptoki/src/functions/encryption.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Encrypting data
 
 use crate::get_pkcs11;

--- a/cryptoki/src/functions/general_purpose.rs
+++ b/cryptoki/src/functions/general_purpose.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! General-purpose functions
 
 use crate::get_pkcs11;

--- a/cryptoki/src/functions/key_management.rs
+++ b/cryptoki/src/functions/key_management.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Key management functions
 
 use crate::get_pkcs11;

--- a/cryptoki/src/functions/mod.rs
+++ b/cryptoki/src/functions/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! PKCS11 functions
 
 pub mod decryption;

--- a/cryptoki/src/functions/object_management.rs
+++ b/cryptoki/src/functions/object_management.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Object management functions
 
 use crate::get_pkcs11;

--- a/cryptoki/src/functions/session_management.rs
+++ b/cryptoki/src/functions/session_management.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Session management functions
 
 use crate::get_pkcs11;

--- a/cryptoki/src/functions/signing_macing.rs
+++ b/cryptoki/src/functions/signing_macing.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Signing and authentication functions
 
 use crate::get_pkcs11;

--- a/cryptoki/src/functions/slot_token_management.rs
+++ b/cryptoki/src/functions/slot_token_management.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Slot and token management functions
 
 use crate::get_pkcs11;

--- a/cryptoki/src/lib.rs
+++ b/cryptoki/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Rust PKCS11 new abstraction
 //!
 //! The items in the new module only expose idiomatic and safe Rust types and functions to

--- a/cryptoki/src/objects/mod.rs
+++ b/cryptoki/src/objects/mod.rs
@@ -1,1 +1,3 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! PKCS11 objects

--- a/cryptoki/src/types/function.rs
+++ b/cryptoki/src/types/function.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Function types
 
 use crate::{Error, Result};

--- a/cryptoki/src/types/locking.rs
+++ b/cryptoki/src/types/locking.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Locking related type
 
 use crate::types::Flags;

--- a/cryptoki/src/types/mechanism/mod.rs
+++ b/cryptoki/src/types/mechanism/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Data types for mechanisms
 
 pub mod rsa;

--- a/cryptoki/src/types/mechanism/rsa.rs
+++ b/cryptoki/src/types/mechanism/rsa.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! RSA mechanism types
 
 use crate::types::mechanism::{Mechanism, MechanismType};

--- a/cryptoki/src/types/mod.rs
+++ b/cryptoki/src/types/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! PKCS11 General Data Types
 
 pub mod function;

--- a/cryptoki/src/types/object.rs
+++ b/cryptoki/src/types/object.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Object types
 
 use crate::types::mechanism::MechanismType;

--- a/cryptoki/src/types/session.rs
+++ b/cryptoki/src/types/session.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Session types
 
 use crate::types::slot_token::Slot;

--- a/cryptoki/src/types/slot_token.rs
+++ b/cryptoki/src/types/slot_token.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 // Depending on the target, CK_SLOT_ID is not u64
 #![allow(clippy::useless_conversion)]
 #![allow(trivial_numeric_casts)]

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 mod common;
 
 use common::init_pins;

--- a/cryptoki/tests/common.rs
+++ b/cryptoki/tests/common.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 use cryptoki::types::locking::CInitializeArgs;
 use cryptoki::types::session::UserType;
 use cryptoki::types::slot_token::Slot;


### PR DESCRIPTION
This PR adds the standard Parsec copyright:

```
// Copyright 2021 Contributors to the Parsec project.
// SPDX-License-Identifier: Apache-2.0
```

on top of every Rust file.

@nickray Since you already made modifications to the original codebase, are you ok with this? "Contributors to the Parsec project" is an umbrella term for all contributors and you can add your name/organization to the list [here](https://github.com/parallaxsecond/parsec/blob/master/CONTRIBUTORS.md).