### PR TITLE
Add the generate-bindings feature to top-level

### DIFF
--- a/cryptoki/Cargo.toml
+++ b/cryptoki/Cargo.toml
@@ -27,3 +27,4 @@ serial_test_derive = "0.5.1"
 
 [features]
 psa-crypto-conversions = ["psa-crypto"]
+generate-bindings = ["cryptoki-sys/generate-bindings"]


### PR DESCRIPTION
This allows people using the cryptoki crate through another crate (like
parsec) to generate the bindings if their target triple is not
supported.