### PR TITLE
Prepare 0.1.1 release

### DIFF
--- a/cryptoki-sys/Cargo.toml
+++ b/cryptoki-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptoki-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Contributors to the Parsec project"]
 edition = '2018'
 description = "FFI wrapper around the PKCS #11 API"

--- a/cryptoki/Cargo.toml
+++ b/cryptoki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptoki"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Contributors to the Parsec project"]
 edition = '2018'
 description = "Rust-native wrapper around the PKCS #11 API"
@@ -17,7 +17,7 @@ log = "0.4.14"
 derivative = "2.2.0"
 secrecy = "0.7.0"
 psa-crypto = { version = "0.8.0", default-features = false, optional = true }
-cryptoki-sys = { path = "../cryptoki-sys", version = "0.1.0" }
+cryptoki-sys = { path = "../cryptoki-sys", version = "0.1.1" }
 
 [dev-dependencies]
 num-traits = "0.2.14"


### PR DESCRIPTION
The `generate-bindings` feature is needed.