### PR TITLE
Add ECC key generation

### DIFF
--- a/cryptoki/src/types/mechanism/mod.rs
+++ b/cryptoki/src/types/mechanism/mod.rs
@@ -41,6 +41,15 @@ impl MechanismType {
         val: CKM_RSA_PKCS_OAEP,
     };
 
+    // ECC
+    /// EC key pair generation mechanism
+    pub const ECC_KEY_PAIR_GEN: MechanismType = MechanismType {
+        val: CKM_EC_KEY_PAIR_GEN,
+    };
+
+    /// ECDSA mechanism
+    pub const ECDSA: MechanismType = MechanismType { val: CKM_ECDSA };
+
     // SHA-n
     /// SHA-1 mechanism
     pub const SHA1: MechanismType = MechanismType { val: CKM_SHA_1 };
@@ -50,9 +59,6 @@ impl MechanismType {
     pub const SHA384: MechanismType = MechanismType { val: CKM_SHA384 };
     /// SHA-512 mechanism
     pub const SHA512: MechanismType = MechanismType { val: CKM_SHA512 };
-
-    /// ECDSA mechanism
-    pub const ECDSA: MechanismType = MechanismType { val: CKM_ECDSA };
 }
 
 impl Deref for MechanismType {
@@ -92,6 +98,7 @@ impl TryFrom<CK_MECHANISM_TYPE> for MechanismType {
 }
 
 #[derive(Copy, Debug, Clone)]
+#[non_exhaustive]
 /// Type defining a specific mechanism and its parameters
 pub enum Mechanism {
     // RSA
@@ -107,6 +114,12 @@ pub enum Mechanism {
     /// defined in PKCS #1
     RsaPkcsOaep(rsa::PkcsOaepParams),
 
+    // ECC
+    /// EC key pair generation
+    EccKeyPairGen,
+    /// ECDSA mechanism
+    Ecdsa,
+
     // SHA-n
     /// SHA-1 mechanism
     Sha1,
@@ -116,9 +129,6 @@ pub enum Mechanism {
     Sha384,
     /// SHA-512 mechanism
     Sha512,
-
-    /// ECDSA mechanism
-    Ecdsa,
 }
 
 impl Mechanism {
@@ -130,12 +140,13 @@ impl Mechanism {
             Mechanism::RsaPkcsPss(_) => MechanismType::RSA_PKCS_PSS,
             Mechanism::RsaPkcsOaep(_) => MechanismType::RSA_PKCS_OAEP,
 
+            Mechanism::EccKeyPairGen => MechanismType::ECC_KEY_PAIR_GEN,
+            Mechanism::Ecdsa => MechanismType::ECDSA,
+
             Mechanism::Sha1 => MechanismType::SHA1,
             Mechanism::Sha256 => MechanismType::SHA256,
             Mechanism::Sha384 => MechanismType::SHA384,
             Mechanism::Sha512 => MechanismType::SHA512,
-
-            Mechanism::Ecdsa => MechanismType::ECDSA,
         }
     }
 }
@@ -165,6 +176,7 @@ impl From<&Mechanism> for CK_MECHANISM {
             | Mechanism::Sha256
             | Mechanism::Sha384
             | Mechanism::Sha512
+            | Mechanism::EccKeyPairGen
             | Mechanism::Ecdsa => CK_MECHANISM {
                 mechanism,
                 pParameter: null_mut(),

--- a/cryptoki/src/types/mechanism/mod.rs
+++ b/cryptoki/src/types/mechanism/mod.rs
@@ -212,6 +212,9 @@ impl TryFrom<psa_crypto::types::algorithm::Algorithm> for Mechanism {
                 mgf: rsa::PkcsMgfType::from_psa_crypto_hash(hash_alg)?,
                 s_len: hash_alg.hash_length().try_into()?,
             })),
+            Algorithm::AsymmetricSignature(AsymmetricSignature::Ecdsa { .. }) => {
+                Ok(Mechanism::Ecdsa)
+            }
             Algorithm::AsymmetricEncryption(AsymmetricEncryption::RsaOaep { hash_alg }) => {
                 Ok(Mechanism::RsaPkcsOaep(rsa::PkcsOaepParams {
                     hash_alg: Mechanism::try_from(Algorithm::from(hash_alg))?.mechanism_type(),

--- a/cryptoki/src/types/object.rs
+++ b/cryptoki/src/types/object.rs
@@ -13,6 +13,7 @@ use std::ffi::c_void;
 use std::ops::Deref;
 
 #[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
 /// Type of an attribute
 pub enum AttributeType {
     /// List of mechanisms allowed to be used with the key
@@ -27,6 +28,8 @@ pub enum AttributeType {
     Decrypt,
     /// Determines if it is possible to derive other keys from the key
     Derive,
+    /// Parameters defining an elliptic curve
+    EcParams,
     /// DER-encoded Elliptic Curve point
     EcPoint,
     /// Determines if a key supports encryption
@@ -82,6 +85,7 @@ impl From<AttributeType> for CK_ATTRIBUTE_TYPE {
             AttributeType::Copyable => CKA_COPYABLE,
             AttributeType::Decrypt => CKA_DECRYPT,
             AttributeType::Derive => CKA_DERIVE,
+            AttributeType::EcParams => CKA_EC_PARAMS,
             AttributeType::EcPoint => CKA_EC_POINT,
             AttributeType::Encrypt => CKA_ENCRYPT,
             AttributeType::Extractable => CKA_EXTRACTABLE,
@@ -119,6 +123,7 @@ impl TryFrom<CK_ATTRIBUTE_TYPE> for AttributeType {
             CKA_COPYABLE => Ok(AttributeType::Copyable),
             CKA_DECRYPT => Ok(AttributeType::Decrypt),
             CKA_DERIVE => Ok(AttributeType::Derive),
+            CKA_EC_PARAMS => Ok(AttributeType::EcParams),
             CKA_EC_POINT => Ok(AttributeType::EcPoint),
             CKA_ENCRYPT => Ok(AttributeType::Encrypt),
             CKA_EXTRACTABLE => Ok(AttributeType::Extractable),
@@ -150,6 +155,7 @@ impl TryFrom<CK_ATTRIBUTE_TYPE> for AttributeType {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 /// Attribute value
 pub enum Attribute {
     /// List of mechanisms allowed to be used with the key
@@ -164,6 +170,8 @@ pub enum Attribute {
     Decrypt(Bbool),
     /// Determines if it is possible to derive other keys from the key
     Derive(Bbool),
+    /// Parameters describing an elliptic curve
+    EcParams(Vec<u8>),
     /// Elliptic Curve point
     EcPoint(Vec<u8>),
     /// Determines if a key supports encryption
@@ -220,6 +228,7 @@ impl Attribute {
             Attribute::Copyable(_) => AttributeType::Copyable,
             Attribute::Decrypt(_) => AttributeType::Decrypt,
             Attribute::Derive(_) => AttributeType::Derive,
+            Attribute::EcParams(_) => AttributeType::EcParams,
             Attribute::EcPoint(_) => AttributeType::EcPoint,
             Attribute::Encrypt(_) => AttributeType::Encrypt,
             Attribute::Extractable(_) => AttributeType::Extractable,
@@ -265,6 +274,7 @@ impl Attribute {
             | Attribute::Wrap(_) => 1,
             Attribute::Base(_) => 1,
             Attribute::Class(_) => std::mem::size_of::<CK_OBJECT_CLASS>(),
+            Attribute::EcParams(bytes) => bytes.len(),
             Attribute::EcPoint(bytes) => bytes.len(),
             Attribute::KeyType(_) => std::mem::size_of::<CK_KEY_TYPE>(),
             Attribute::Label(label) => std::mem::size_of::<CK_UTF8CHAR>() * label.len(),
@@ -313,6 +323,7 @@ impl Attribute {
             }
             // Vec<u8>
             Attribute::Base(bytes)
+            | Attribute::EcParams(bytes)
             | Attribute::EcPoint(bytes)
             | Attribute::Label(bytes)
             | Attribute::Prime(bytes)
@@ -380,6 +391,7 @@ impl TryFrom<CK_ATTRIBUTE> for Attribute {
             )),
             // Vec<u8>
             AttributeType::Base => Ok(Attribute::Base(val.to_vec())),
+            AttributeType::EcParams => Ok(Attribute::EcParams(val.to_vec())),
             AttributeType::EcPoint => Ok(Attribute::EcPoint(val.to_vec())),
             AttributeType::Label => Ok(Attribute::Label(val.to_vec())),
             AttributeType::Prime => Ok(Attribute::Prime(val.to_vec())),


### PR DESCRIPTION
This commit adds generation of EC keys as a mechanism, along with the
EcParameters attribute required by this mechanism.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>