### PR TITLE
Add functions and types needed for ECDH-based decryption

### DIFF
--- a/cryptoki/src/functions/key_management.rs
+++ b/cryptoki/src/functions/key_management.rs
@@ -45,4 +45,29 @@ impl<'a> Session<'a> {
             ObjectHandle::new(priv_handle),
         ))
     }
+
+    /// Derives a key from a base key
+    pub fn derive_key(
+        &self,
+        mechanism: &Mechanism,
+        base_key: ObjectHandle,
+        template: &[Attribute],
+    ) -> Result<ObjectHandle> {
+        let mut mechanism: CK_MECHANISM = mechanism.into();
+        let mut template: Vec<CK_ATTRIBUTE> = template.iter().map(|attr| attr.into()).collect();
+        let mut handle = 0;
+        unsafe {
+            Rv::from(get_pkcs11!(self.client(), C_DeriveKey)(
+                self.handle(),
+                &mut mechanism as CK_MECHANISM_PTR,
+                base_key.handle(),
+                template.as_mut_ptr(),
+                template.len().try_into()?,
+                &mut handle,
+            ))
+            .into_result()?;
+        }
+
+        Ok(ObjectHandle::new(handle))
+    }
 }

--- a/cryptoki/src/types/mechanism/elliptic_curve.rs
+++ b/cryptoki/src/types/mechanism/elliptic_curve.rs
@@ -1,0 +1,81 @@
+//! ECDH mechanism types
+
+use crate::{types::Ulong, Error, Result};
+use cryptoki_sys::*;
+use log::error;
+use std::convert::TryFrom;
+use std::ffi::c_void;
+use std::ops::Deref;
+
+/// ECDH derivation parameters.
+///
+/// The elliptic curve Diffie-Hellman (ECDH) key derivation mechanism
+/// is a mechanism for key derivation based on the Diffie-Hellman
+/// version of the elliptic curve key agreement scheme, as defined in
+/// ANSI X9.63, where each party contributes one key pair all using
+/// the same EC domain parameters.
+///
+/// This structure wraps CK_ECDH1_DERIVE_PARAMS structure.
+#[derive(Copy, Debug, Clone)]
+#[repr(C)]
+pub struct Ecdh1DeriveParams {
+    /// Key derivation function
+    pub kdf: EcKdfType,
+    /// Length of the optional shared data used by some of the key
+    /// derivation functions
+    pub shared_data_len: Ulong,
+    /// Address of the optional data or `std::ptr::null()` of there is
+    /// no shared data
+    pub shared_data: *const c_void,
+    /// Length of the other party's public key
+    pub public_data_len: Ulong,
+    /// Pointer to the other party public key
+    pub public_data: *const c_void,
+}
+
+/// Key Derivation Function applied to derive keying data from a shared secret.
+///
+/// The key derivation function will be used by the EC key agreement schemes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct EcKdfType {
+    val: CK_EC_KDF_TYPE,
+}
+
+impl EcKdfType {
+    /// The null transformation. The derived key value is produced by
+    /// taking bytes from the left of the agreed value. The new key
+    /// size is limited to the size of the agreed value.
+    pub const NULL: EcKdfType = EcKdfType { val: CKD_NULL };
+}
+
+impl Deref for EcKdfType {
+    type Target = CK_EC_KDF_TYPE;
+
+    fn deref(&self) -> &Self::Target {
+        &self.val
+    }
+}
+
+impl From<EcKdfType> for CK_EC_KDF_TYPE {
+    fn from(ec_kdf_type: EcKdfType) -> Self {
+        *ec_kdf_type
+    }
+}
+
+impl TryFrom<CK_EC_KDF_TYPE> for EcKdfType {
+    type Error = Error;
+
+    fn try_from(ec_kdf_type: CK_EC_KDF_TYPE) -> Result<Self> {
+        match ec_kdf_type {
+            CKD_NULL => Ok(EcKdfType::NULL),
+            other => {
+                error!(
+                    "Key derivation function type {} is not one of the valid values.",
+                    other
+                );
+                Err(Error::InvalidValue)
+            }
+        }
+    }
+}

--- a/cryptoki/src/types/object.rs
+++ b/cryptoki/src/types/object.rs
@@ -508,6 +508,10 @@ impl KeyType {
     pub const RSA: KeyType = KeyType { val: CKK_RSA };
     /// EC key
     pub const EC: KeyType = KeyType { val: CKK_EC };
+    /// Generic secret
+    pub const GENERIC_SECRET: KeyType = KeyType {
+        val: CKK_GENERIC_SECRET,
+    };
 }
 
 impl Deref for KeyType {
@@ -531,6 +535,7 @@ impl TryFrom<CK_KEY_TYPE> for KeyType {
         match key_type {
             CKK_RSA => Ok(KeyType::RSA),
             CKK_EC => Ok(KeyType::EC),
+            CKK_GENERIC_SECRET => Ok(KeyType::GENERIC_SECRET),
             other => {
                 error!("Key type {} is not supported.", other);
                 Err(Error::NotSupported)


### PR DESCRIPTION
Hi folks! :wave: it's me again :)

This set of changes adds:
  - `derive_key` function,
  - new mechanism used with ECDH (with associated type),
  - generic secret type that is used to hold the generated secret in token's memory.

As usual, I've tested that with Yubikey that I have and my shim code to Sequoia for a nice secp256r1 based ECDH-decryption.

It works fine :)