### PR TITLE
Add get_token_info

### DIFF
--- a/cryptoki/src/functions/slot_token_management.rs
+++ b/cryptoki/src/functions/slot_token_management.rs
@@ -4,10 +4,11 @@
 
 use crate::get_pkcs11;
 use crate::types::function::Rv;
-use crate::types::slot_token::Slot;
+use crate::types::slot_token::{Slot, TokenInfo};
 use crate::Pkcs11;
 use crate::Result;
 use crate::Session;
+use cryptoki_sys::CK_TOKEN_INFO;
 use secrecy::{ExposeSecret, Secret};
 use std::convert::TryInto;
 use std::ffi::CString;
@@ -93,6 +94,19 @@ impl Pkcs11 {
                 label.as_ptr() as *mut u8,
             ))
             .into_result()
+        }
+    }
+
+    /// Returns information about a specific token
+    pub fn get_token_info(&self, slot: Slot) -> Result<TokenInfo> {
+        unsafe {
+            let mut token_info = CK_TOKEN_INFO::default();
+            Rv::from(get_pkcs11!(self, C_GetTokenInfo)(
+                slot.into(),
+                &mut token_info,
+            ))
+            .into_result()?;
+            Ok(TokenInfo::new(token_info))
         }
     }
 }

--- a/cryptoki/src/types/slot_token.rs
+++ b/cryptoki/src/types/slot_token.rs
@@ -7,8 +7,9 @@
 //! Slot and token types
 
 use crate::{Error, Result};
-use cryptoki_sys::CK_SLOT_ID;
+use cryptoki_sys::{CK_SLOT_ID, CK_TOKEN_INFO};
 use std::convert::{TryFrom, TryInto};
+use std::ops::Deref;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Type identifying a slot
@@ -40,5 +41,45 @@ impl TryFrom<u64> for Slot {
 impl From<Slot> for CK_SLOT_ID {
     fn from(slot: Slot) -> Self {
         slot.slot_id
+    }
+}
+
+/// Contains information about a token
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TokenInfo {
+    val: CK_TOKEN_INFO,
+}
+
+impl TokenInfo {
+    pub(crate) fn new(val: CK_TOKEN_INFO) -> Self {
+        Self { val }
+    }
+
+    /// Returns the ID of the device manufacturer
+    pub fn get_manufacturer_id(&self) -> String {
+        String::from_utf8_lossy(&self.val.manufacturerID)
+            .trim_end()
+            .to_string()
+    }
+
+    /// Returns the character-string serial number of the device
+    pub fn get_serial_number(&self) -> String {
+        String::from_utf8_lossy(&self.val.serialNumber)
+            .trim_end()
+            .to_string()
+    }
+}
+
+impl Deref for TokenInfo {
+    type Target = CK_TOKEN_INFO;
+
+    fn deref(&self) -> &Self::Target {
+        &self.val
+    }
+}
+
+impl From<TokenInfo> for CK_TOKEN_INFO {
+    fn from(token_info: TokenInfo) -> Self {
+        *token_info
     }
 }

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -285,6 +285,14 @@ fn import_export() {
 
 #[test]
 #[serial]
+fn get_token_info() {
+    let (pkcs11, slot) = init_pins();
+    let info = pkcs11.get_token_info(slot).unwrap();
+    assert_eq!("SoftHSM project", info.get_manufacturer_id());
+}
+
+#[test]
+#[serial]
 fn login_feast() {
     const SESSIONS: usize = 100;
 


### PR DESCRIPTION
Okay folks, I'll need some more help on this one.

* I'm not sure where to place the `TokenInfo` struct (should it be in the `-sys` crate?)
* about the struct members themselves: for example currently they are raw types that are read from the PKCS#11 driver but maybe it would be nice to clean them up (e.g. all strings - as usual in PKCS#11 - are space padded - see the unit test).
* `get_token_info` uses some raw ffi code I found that works but I'm not sure if that's the best approach.

Please ignore placeholder docs for a moment. I'll add them when other issues are fixed :)