### PR TITLE
Implement `CKM_EC_KEY_PAIR_GEN` to `MechanismType` conversion

### DIFF
--- a/cryptoki/src/types/mechanism/mod.rs
+++ b/cryptoki/src/types/mechanism/mod.rs
@@ -108,6 +108,7 @@ impl TryFrom<CK_MECHANISM_TYPE> for MechanismType {
             CKM_SHA256 => Ok(MechanismType::SHA256),
             CKM_SHA384 => Ok(MechanismType::SHA384),
             CKM_SHA512 => Ok(MechanismType::SHA512),
+            CKM_EC_KEY_PAIR_GEN => Ok(MechanismType::ECC_KEY_PAIR_GEN),
             CKM_ECDH1_DERIVE => Ok(MechanismType::ECDH1_DERIVE),
             CKM_ECDSA => Ok(MechanismType::ECDSA),
             CKM_SHA256_RSA_PKCS => Ok(MechanismType::SHA256_RSA_PKCS),


### PR DESCRIPTION
I found `CKM_EC_KEY_PAIR_GEN` this to be missing during the implementation of #31.