### PR TITLE
Add secret key generation and key wrapping functions

### DIFF
--- a/cryptoki/src/types/mechanism/mod.rs
+++ b/cryptoki/src/types/mechanism/mod.rs
@@ -45,10 +45,12 @@ impl MechanismType {
 
     // DES
     /// DES3
+    /// Note that DES3 is deprecated. See https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf section 2, p. 6.
     pub const DES3_KEY_GEN: MechanismType = MechanismType {
         val: CKM_DES3_KEY_GEN,
     };
-    /// DES3 CBC
+    /// DES3 ECB
+    /// Note that DES3 is deprecated. See https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf section 2, p. 6.
     pub const DES3_ECB: MechanismType = MechanismType { val: CKM_DES3_ECB };
 
     // ECC

--- a/cryptoki/src/types/mechanism/mod.rs
+++ b/cryptoki/src/types/mechanism/mod.rs
@@ -43,6 +43,12 @@ impl MechanismType {
         val: CKM_RSA_PKCS_OAEP,
     };
 
+    // DES
+    /// DES3
+    pub const DES3_KEY_GEN: MechanismType = MechanismType {
+        val: CKM_DES3_KEY_GEN,
+    };
+
     // ECC
     /// EC key pair generation mechanism
     pub const ECC_KEY_PAIR_GEN: MechanismType = MechanismType {
@@ -117,6 +123,7 @@ impl TryFrom<CK_MECHANISM_TYPE> for MechanismType {
             CKM_SHA256 => Ok(MechanismType::SHA256),
             CKM_SHA384 => Ok(MechanismType::SHA384),
             CKM_SHA512 => Ok(MechanismType::SHA512),
+            CKM_DES3_KEY_GEN => Ok(MechanismType::DES3_KEY_GEN),
             CKM_EC_KEY_PAIR_GEN => Ok(MechanismType::ECC_KEY_PAIR_GEN),
             CKM_EC_EDWARDS_KEY_PAIR_GEN => Ok(MechanismType::ECC_EDWARDS_KEY_PAIR_GEN),
             CKM_EC_MONTGOMERY_KEY_PAIR_GEN => Ok(MechanismType::ECC_MONTGOMERY_KEY_PAIR_GEN),
@@ -149,6 +156,10 @@ pub enum Mechanism {
     /// Multi-purpose mechanism based on the RSA public-key cryptosystem and the OAEP block format
     /// defined in PKCS #1
     RsaPkcsOaep(rsa::PkcsOaepParams),
+
+    // DES
+    /// DES3
+    Des3KeyGen,
 
     // ECC
     /// EC key pair generation
@@ -189,6 +200,8 @@ impl Mechanism {
             Mechanism::RsaPkcs => MechanismType::RSA_PKCS,
             Mechanism::RsaPkcsPss(_) => MechanismType::RSA_PKCS_PSS,
             Mechanism::RsaPkcsOaep(_) => MechanismType::RSA_PKCS_OAEP,
+
+            Mechanism::Des3KeyGen => MechanismType::DES3_KEY_GEN,
 
             Mechanism::EccKeyPairGen => MechanismType::ECC_KEY_PAIR_GEN,
             Mechanism::EccEdwardsKeyPairGen => MechanismType::ECC_EDWARDS_KEY_PAIR_GEN,
@@ -240,6 +253,7 @@ impl From<&Mechanism> for CK_MECHANISM {
             | Mechanism::Sha256
             | Mechanism::Sha384
             | Mechanism::Sha512
+            | Mechanism::Des3KeyGen
             | Mechanism::EccKeyPairGen
             | Mechanism::EccEdwardsKeyPairGen
             | Mechanism::EccMontgomeryKeyPairGen

--- a/cryptoki/src/types/mechanism/mod.rs
+++ b/cryptoki/src/types/mechanism/mod.rs
@@ -48,6 +48,8 @@ impl MechanismType {
     pub const DES3_KEY_GEN: MechanismType = MechanismType {
         val: CKM_DES3_KEY_GEN,
     };
+    /// DES3 CBC
+    pub const DES3_ECB: MechanismType = MechanismType { val: CKM_DES3_ECB };
 
     // ECC
     /// EC key pair generation mechanism
@@ -124,6 +126,7 @@ impl TryFrom<CK_MECHANISM_TYPE> for MechanismType {
             CKM_SHA384 => Ok(MechanismType::SHA384),
             CKM_SHA512 => Ok(MechanismType::SHA512),
             CKM_DES3_KEY_GEN => Ok(MechanismType::DES3_KEY_GEN),
+            CKM_DES3_ECB => Ok(MechanismType::DES3_ECB),
             CKM_EC_KEY_PAIR_GEN => Ok(MechanismType::ECC_KEY_PAIR_GEN),
             CKM_EC_EDWARDS_KEY_PAIR_GEN => Ok(MechanismType::ECC_EDWARDS_KEY_PAIR_GEN),
             CKM_EC_MONTGOMERY_KEY_PAIR_GEN => Ok(MechanismType::ECC_MONTGOMERY_KEY_PAIR_GEN),
@@ -160,6 +163,8 @@ pub enum Mechanism {
     // DES
     /// DES3
     Des3KeyGen,
+    /// DES3 ECB
+    Des3Ecb,
 
     // ECC
     /// EC key pair generation
@@ -202,6 +207,7 @@ impl Mechanism {
             Mechanism::RsaPkcsOaep(_) => MechanismType::RSA_PKCS_OAEP,
 
             Mechanism::Des3KeyGen => MechanismType::DES3_KEY_GEN,
+            Mechanism::Des3Ecb => MechanismType::DES3_ECB,
 
             Mechanism::EccKeyPairGen => MechanismType::ECC_KEY_PAIR_GEN,
             Mechanism::EccEdwardsKeyPairGen => MechanismType::ECC_EDWARDS_KEY_PAIR_GEN,
@@ -254,6 +260,7 @@ impl From<&Mechanism> for CK_MECHANISM {
             | Mechanism::Sha384
             | Mechanism::Sha512
             | Mechanism::Des3KeyGen
+            | Mechanism::Des3Ecb
             | Mechanism::EccKeyPairGen
             | Mechanism::EccEdwardsKeyPairGen
             | Mechanism::EccMontgomeryKeyPairGen

--- a/cryptoki/src/types/object.rs
+++ b/cryptoki/src/types/object.rs
@@ -531,6 +531,7 @@ impl KeyType {
         val: CKK_GENERIC_SECRET,
     };
     /// DES3 secret
+    /// Note that DES3 is deprecated. See https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf section 2, p. 6.
     pub const DES3: KeyType = KeyType { val: CKK_DES3 };
 }
 

--- a/cryptoki/src/types/object.rs
+++ b/cryptoki/src/types/object.rs
@@ -530,6 +530,8 @@ impl KeyType {
     pub const GENERIC_SECRET: KeyType = KeyType {
         val: CKK_GENERIC_SECRET,
     };
+    /// DES3 secret
+    pub const DES3: KeyType = KeyType { val: CKK_DES3 };
 }
 
 impl Deref for KeyType {
@@ -556,6 +558,7 @@ impl TryFrom<CK_KEY_TYPE> for KeyType {
             CKK_EC_EDWARDS => Ok(KeyType::EC_EDWARDS),
             CKK_EC_MONTGOMERY => Ok(KeyType::EC_MONTGOMERY),
             CKK_GENERIC_SECRET => Ok(KeyType::GENERIC_SECRET),
+            CKK_DES3 => Ok(KeyType::DES3),
             other => {
                 error!("Key type {} is not supported.", other);
                 Err(Error::NotSupported)


### PR DESCRIPTION
Hi folks :wave: 

If you don't mind I'll add the wrap/unwrap feature. The end goal is to securely transfer private keys between tokens or between airgapped machine and a token.

I start modestly with wrapper for `C_WrapKey`. Apparently during work it seems like wrapping private keys with private keys is not possible but among the combinations allowed with the spec is wrapping secret keys with private keys so I also added `C_GenerateKey` for secret (symmetric) 3DES keys and some tests.

Suggestions welcome!