### PR TITLE
Multiple updates to provide additional 'info' function bindings betwe…

### DIFF
--- a/cryptoki/src/functions/general_purpose.rs
+++ b/cryptoki/src/functions/general_purpose.rs
@@ -5,9 +5,10 @@
 use crate::get_pkcs11;
 use crate::types::function::Rv;
 use crate::types::locking::CInitializeArgs;
+use crate::types::Info;
 use crate::Pkcs11;
 use crate::Result;
-use cryptoki_sys::CK_C_INITIALIZE_ARGS;
+use cryptoki_sys::{CK_C_INITIALIZE_ARGS, CK_INFO};
 use std::ptr;
 
 impl Pkcs11 {
@@ -33,4 +34,13 @@ impl Pkcs11 {
     /// Finalize the PKCS11 library. Indicates that the application no longer needs to use PKCS11.
     /// The library is also automatically finalized on drop.
     pub fn finalize(self) {}
+
+    /// Returns the information about the library
+    pub fn get_library_info(&self) -> Result<Info> {
+        let mut info = CK_INFO::default();
+        unsafe {
+            Rv::from(get_pkcs11!(self, C_GetInfo)(&mut info)).into_result()?;
+            Ok(Info::new(info))
+        }
+    }
 }

--- a/cryptoki/src/functions/session_management.rs
+++ b/cryptoki/src/functions/session_management.rs
@@ -4,20 +4,22 @@
 
 use crate::get_pkcs11;
 use crate::types::function::Rv;
-use crate::types::session::{Session, UserType};
+use crate::types::session::{Session, SessionInfo, UserType};
 use crate::types::slot_token::Slot;
-use crate::types::Flags;
+use crate::types::SessionFlags;
 use crate::Pkcs11;
 use crate::Result;
+use cryptoki_sys::CK_SESSION_INFO;
+use std::convert::TryInto;
 
 impl Pkcs11 {
     /// Open a new session with no callback set
-    pub fn open_session_no_callback(&self, slot_id: Slot, flags: Flags) -> Result<Session> {
+    pub fn open_session_no_callback(&self, slot_id: Slot, flags: SessionFlags) -> Result<Session> {
         let mut session_handle = 0;
 
         unsafe {
             Rv::from(get_pkcs11!(self, C_OpenSession)(
-                slot_id.into(),
+                slot_id.try_into()?,
                 flags.into(),
                 // TODO: abstract those types or create new functions for callbacks
                 std::ptr::null_mut(),
@@ -54,5 +56,18 @@ impl<'a> Session<'a> {
     /// Will also be called on drop.
     pub fn logout(&self) -> Result<()> {
         self.client().logout(self)
+    }
+
+    /// Returns the information about a session
+    pub fn get_session_info(&self) -> Result<SessionInfo> {
+        let mut session_info = CK_SESSION_INFO::default();
+        unsafe {
+            Rv::from(get_pkcs11!(self.client(), C_GetSessionInfo)(
+                self.handle(),
+                &mut session_info,
+            ))
+            .into_result()?;
+            Ok(SessionInfo::new(session_info))
+        }
     }
 }

--- a/cryptoki/src/functions/slot_token_management.rs
+++ b/cryptoki/src/functions/slot_token_management.rs
@@ -55,7 +55,7 @@ impl Pkcs11 {
             .into_iter()
             .filter_map(|slot| match self.get_token_info(slot) {
                 Ok(token_info) => {
-                    if token_info.get_flags().token_initialized() {
+                    if token_info.flags().token_initialized() {
                         Some(Ok(slot))
                     } else {
                         None

--- a/cryptoki/src/functions/slot_token_management.rs
+++ b/cryptoki/src/functions/slot_token_management.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Slot and token management functions
 
-use crate::get_pkcs11;
 use crate::types::function::Rv;
 use crate::types::mechanism::{MechanismInfo, MechanismType};
-use crate::types::slot_token::{Slot, TokenInfo};
+use crate::types::slot_token::{Slot, SlotInfo, TokenInfo};
 use crate::Pkcs11;
 use crate::Result;
 use crate::Session;
-use cryptoki_sys::{CK_MECHANISM_INFO, CK_TOKEN_INFO};
+use crate::{get_pkcs11, label_from_str};
+use cryptoki_sys::{CK_MECHANISM_INFO, CK_SLOT_INFO, CK_TOKEN_INFO};
 use secrecy::{ExposeSecret, Secret};
 use std::convert::TryInto;
 use std::ffi::CString;
@@ -101,13 +101,12 @@ impl Pkcs11 {
     /// Initialize a token
     ///
     /// Currently will use an empty label for all tokens.
-    pub fn init_token(&self, slot: Slot, pin: &str) -> Result<()> {
+    pub fn init_token(&self, slot: Slot, pin: &str, label: &str) -> Result<()> {
         let pin = Secret::new(CString::new(pin)?.into_bytes());
-        // FIXME: make a good conversion to the label format
-        let label = [b' '; 32];
+        let label = label_from_str(label);
         unsafe {
             Rv::from(get_pkcs11!(self, C_InitToken)(
-                slot.into(),
+                slot.try_into()?,
                 pin.expose_secret().as_ptr() as *mut u8,
                 pin.expose_secret().len().try_into()?,
                 label.as_ptr() as *mut u8,
@@ -116,12 +115,25 @@ impl Pkcs11 {
         }
     }
 
+    /// Returns the slot info
+    pub fn get_slot_info(&self, slot: Slot) -> Result<SlotInfo> {
+        unsafe {
+            let mut slot_info = CK_SLOT_INFO::default();
+            Rv::from(get_pkcs11!(self, C_GetSlotInfo)(
+                slot.try_into()?,
+                &mut slot_info,
+            ))
+            .into_result()?;
+            Ok(SlotInfo::new(slot_info))
+        }
+    }
+
     /// Returns information about a specific token
     pub fn get_token_info(&self, slot: Slot) -> Result<TokenInfo> {
         unsafe {
             let mut token_info = CK_TOKEN_INFO::default();
             Rv::from(get_pkcs11!(self, C_GetTokenInfo)(
-                slot.into(),
+                slot.try_into()?,
                 &mut token_info,
             ))
             .into_result()?;
@@ -135,7 +147,7 @@ impl Pkcs11 {
 
         unsafe {
             Rv::from(get_pkcs11!(self, C_GetMechanismList)(
-                slot.into(),
+                slot.try_into()?,
                 std::ptr::null_mut(),
                 &mut mechanism_count,
             ))
@@ -146,7 +158,7 @@ impl Pkcs11 {
 
         unsafe {
             Rv::from(get_pkcs11!(self, C_GetMechanismList)(
-                slot.into(),
+                slot.try_into()?,
                 mechanisms.as_mut_ptr(),
                 &mut mechanism_count,
             ))
@@ -167,7 +179,7 @@ impl Pkcs11 {
         unsafe {
             let mut mechanism_info = CK_MECHANISM_INFO::default();
             Rv::from(get_pkcs11!(self, C_GetMechanismInfo)(
-                slot.into(),
+                slot.try_into()?,
                 type_.into(),
                 &mut mechanism_info,
             ))

--- a/cryptoki/src/lib.rs
+++ b/cryptoki/src/lib.rs
@@ -294,7 +294,7 @@ impl Drop for Pkcs11 {
 /// Main Result type
 pub type Result<T> = core::result::Result<T, Error>;
 
-fn str_from_blank_padded(field: &[CK_UTF8CHAR]) -> String {
+fn string_from_blank_padded(field: &[CK_UTF8CHAR]) -> String {
     let decoded_str = String::from_utf8_lossy(field);
     decoded_str.trim_end_matches(' ').to_string()
 }

--- a/cryptoki/src/types/locking.rs
+++ b/cryptoki/src/types/locking.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Locking related type
 
-use crate::types::Flags;
+use crate::types::InitializeFlags;
 use std::ptr;
 
 /// Argument for the initialize function
@@ -16,7 +16,7 @@ pub enum CInitializeArgs {
 
 impl From<CInitializeArgs> for cryptoki_sys::CK_C_INITIALIZE_ARGS {
     fn from(c_initialize_args: CInitializeArgs) -> Self {
-        let mut flags = Flags::default();
+        let mut flags = InitializeFlags::default();
         match c_initialize_args {
             CInitializeArgs::OsThreads => {
                 let _ = flags.set_os_locking_ok(true);

--- a/cryptoki/src/types/mechanism/mod.rs
+++ b/cryptoki/src/types/mechanism/mod.rs
@@ -5,7 +5,7 @@
 pub mod elliptic_curve;
 pub mod rsa;
 
-use crate::types::{Flags, Ulong};
+use crate::types::{MechanismFlags, Ulong};
 use crate::Error;
 use cryptoki_sys::*;
 use log::error;
@@ -323,7 +323,7 @@ impl MechanismInfo {
     }
 
     /// Returns the flags for this mechanism.
-    pub fn flags(&self) -> Flags {
+    pub fn flags(&self) -> MechanismFlags {
         self.val.flags.into()
     }
 }

--- a/cryptoki/src/types/mod.rs
+++ b/cryptoki/src/types/mod.rs
@@ -121,9 +121,15 @@ impl From<InitializeFlags> for CK_FLAGS {
     }
 }
 
-impl From<CK_FLAGS> for InitializeFlags {
-    fn from(flags: CK_FLAGS) -> Self {
-        Self { flags }
+impl TryFrom<CK_FLAGS> for InitializeFlags {
+    type Error = Error;
+
+    fn try_from(flags: CK_FLAGS) -> Result<Self> {
+        if flags & !(CKF_OS_LOCKING_OK | CKF_LIBRARY_CANT_CREATE_OS_THREADS) != 0 {
+            Err(Error::InvalidValue)
+        } else {
+            Ok(Self { flags })
+        }
     }
 }
 

--- a/cryptoki/src/types/mod.rs
+++ b/cryptoki/src/types/mod.rs
@@ -9,30 +9,58 @@ pub mod object;
 pub mod session;
 pub mod slot_token;
 
-use crate::{Error, Result};
+use crate::{str_from_blank_padded, Error, Result};
 use cryptoki_sys::*;
 use log::error;
 use std::convert::TryFrom;
 use std::convert::TryInto;
+use std::fmt::Formatter;
 use std::ops::Deref;
 
+trait Flags: std::fmt::Display {
+    type FlagType: Copy;
+
+    fn get_flag_value(&self) -> Self::FlagType;
+
+    fn get_flag(&self, flag: Self::FlagType) -> bool;
+
+    fn set_flag(&mut self, flag: Self::FlagType, b: bool);
+
+    fn stringify_flag(flag: Self::FlagType) -> &'static str;
+
+    fn stringify_fmt(&self, f: &mut Formatter<'_>, flags: Vec<Self::FlagType>) -> std::fmt::Result {
+        let mut first_done = false;
+        for flag in flags.iter() {
+            if self.get_flag(*flag) {
+                if first_done {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{}", Self::stringify_flag(*flag))?;
+                first_done = true;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy)]
-/// Collection of boolean flags
-pub struct Flags {
+/// Collection of flags defined for [`CK_SLOT_INFO`]
+pub struct InitializeFlags {
     flags: CK_FLAGS,
 }
 
-impl Flags {
-    /// Create a new instance with all flags set to false
-    pub fn new() -> Self {
-        Flags::default()
+impl Flags for InitializeFlags {
+    type FlagType = CK_FLAGS;
+
+    fn get_flag_value(&self) -> Self::FlagType {
+        self.flags
     }
 
-    fn get_flag(&self, flag: CK_FLAGS) -> bool {
-        self.flags & flag == flag
+    fn get_flag(&self, flag: Self::FlagType) -> bool {
+        self.get_flag_value() & flag == flag
     }
 
-    fn set_flag(&mut self, flag: CK_FLAGS, b: bool) {
+    fn set_flag(&mut self, flag: Self::FlagType, b: bool) {
         if b {
             self.flags |= flag;
         } else {
@@ -40,575 +68,822 @@ impl Flags {
         }
     }
 
-    /// Get the TOKEN_PRESENT flag
-    pub fn token_present(&self) -> bool {
-        self.get_flag(CKF_TOKEN_PRESENT)
-    }
-
-    /// Set the TOKEN_PRESENT flag
-    pub fn set_token_present(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_TOKEN_PRESENT, b);
-        self
-    }
-
-    /// Get the REMOVABLE_DEVICE flag
-    pub fn removable_device(&self) -> bool {
-        self.get_flag(CKF_REMOVABLE_DEVICE)
-    }
-
-    /// Set the REMOVABLE_DEVICE flag
-    pub fn set_removable_device(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_REMOVABLE_DEVICE, b);
-        self
-    }
-
-    /// Get the HW_SLOT flag
-    pub fn hw_slot(&self) -> bool {
-        self.get_flag(CKF_HW_SLOT)
-    }
-
-    /// Set the HW_SLOT flag
-    pub fn set_hw_slot(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_HW_SLOT, b);
-        self
-    }
-
-    /// Get the ARRAY_ATTRIBUTE flag
-    pub fn array_attribute(&self) -> bool {
-        self.get_flag(CKF_ARRAY_ATTRIBUTE)
-    }
-
-    /// Set the ARRAY_ATTRIBUTE flag
-    pub fn set_array_attribute(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_ARRAY_ATTRIBUTE, b);
-        self
-    }
-
-    /// Get the RNG flag
-    pub fn rng(&self) -> bool {
-        self.get_flag(CKF_RNG)
-    }
-
-    /// Set the RNG flag
-    pub fn set_rng(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_RNG, b);
-        self
-    }
-
-    /// Get the WRITE_PROTECTED flag
-    pub fn write_protected(&self) -> bool {
-        self.get_flag(CKF_WRITE_PROTECTED)
-    }
-
-    /// Set the WRITE_PROTECTED flag
-    pub fn set_write_protected(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_WRITE_PROTECTED, b);
-        self
-    }
-
-    /// Get the LOGIN_REQUIRED flag
-    pub fn login_required(&self) -> bool {
-        self.get_flag(CKF_LOGIN_REQUIRED)
-    }
-
-    /// Set the LOGIN_REQUIRED flag
-    pub fn set_login_required(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_LOGIN_REQUIRED, b);
-        self
-    }
-
-    /// Get the USER_PIN_INITIALIZED flag
-    pub fn user_pin_initialized(&self) -> bool {
-        self.get_flag(CKF_USER_PIN_INITIALIZED)
-    }
-
-    /// Set the USER_PIN_INITIALIZED flag
-    pub fn set_user_pin_initialized(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_USER_PIN_INITIALIZED, b);
-        self
-    }
-
-    /// Get the RESTORE_KEY_NOT_NEEDED flag
-    pub fn restore_key_not_needed(&self) -> bool {
-        self.get_flag(CKF_RESTORE_KEY_NOT_NEEDED)
-    }
-
-    /// Set the RESTORE_KEY_NOT_NEEDED flag
-    pub fn set_restore_key_not_needed(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_RESTORE_KEY_NOT_NEEDED, b);
-        self
-    }
-
-    /// Get the CLOCK_ON_TOKEN flag
-    pub fn clock_on_token(&self) -> bool {
-        self.get_flag(CKF_CLOCK_ON_TOKEN)
-    }
-
-    /// Set the CLOCK_ON_TOKEN flag
-    pub fn set_clock_on_token(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_CLOCK_ON_TOKEN, b);
-        self
-    }
-
-    /// Get the PROTECTED_AUTHENTICATION flag
-    pub fn protected_authentication_path(&self) -> bool {
-        self.get_flag(CKF_PROTECTED_AUTHENTICATION_PATH)
-    }
-
-    /// Set the PROTECTED_AUTHENTICATION flag
-    pub fn set_protected_authentication_path(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_PROTECTED_AUTHENTICATION_PATH, b);
-        self
-    }
-
-    /// Get the DUAL_CRYPTO_OPERATIONS flag
-    pub fn dual_crypto_operations(&self) -> bool {
-        self.get_flag(CKF_DUAL_CRYPTO_OPERATIONS)
-    }
-
-    /// Set the DUAL_CRYPTO_OPERATIONS flag
-    pub fn set_dual_crypto_operations(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_DUAL_CRYPTO_OPERATIONS, b);
-        self
-    }
-
-    /// Get the TOKEN_INITIALIZED flag
-    pub fn token_initialized(&self) -> bool {
-        self.get_flag(CKF_TOKEN_INITIALIZED)
-    }
-
-    /// Set the TOKEN_INITIALIZED flag
-    pub fn set_token_initialized(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_TOKEN_INITIALIZED, b);
-        self
-    }
-
-    /// Get the SECONDARY_AUTHENTICATION flag
-    pub fn secondary_authentication(&self) -> bool {
-        self.get_flag(CKF_SECONDARY_AUTHENTICATION)
-    }
-
-    /// Set the SECONDARY_AUTHENTICATION flag
-    pub fn set_secondary_authentication(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_SECONDARY_AUTHENTICATION, b);
-        self
-    }
-
-    /// Get the USER_PIN_COUNT_LOW flag
-    pub fn user_pin_count_low(&self) -> bool {
-        self.get_flag(CKF_USER_PIN_COUNT_LOW)
-    }
-
-    /// Set the USER_PIN_COUNT_LOW flag
-    pub fn set_user_pin_count_low(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_USER_PIN_COUNT_LOW, b);
-        self
-    }
-
-    /// Get the USER_PIN_FINAL_TRY flag
-    pub fn user_pin_final_try(&self) -> bool {
-        self.get_flag(CKF_USER_PIN_FINAL_TRY)
-    }
-
-    /// Set the USER_PIN_FINAL_TRY flag
-    pub fn set_user_pin_final_try(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_USER_PIN_FINAL_TRY, b);
-        self
-    }
-
-    /// Get the USER_PIN_LOCKED flag
-    pub fn user_pin_locked(&self) -> bool {
-        self.get_flag(CKF_USER_PIN_LOCKED)
-    }
-
-    /// Set the USER_PIN_LOCKED flag
-    pub fn set_user_pin_locked(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_USER_PIN_LOCKED, b);
-        self
-    }
-
-    /// Get the USER_PIN_TO_BE_CHANGED flag
-    pub fn user_pin_to_be_changed(&self) -> bool {
-        self.get_flag(CKF_USER_PIN_TO_BE_CHANGED)
-    }
-
-    /// Set the USER_PIN_TO_BE_CHANGED flag
-    pub fn set_user_pin_to_be_changed(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_USER_PIN_TO_BE_CHANGED, b);
-        self
-    }
-
-    /// Get the SO_PIN_COUNT_LOW flag
-    pub fn so_pin_count_low(&self) -> bool {
-        self.get_flag(CKF_SO_PIN_COUNT_LOW)
-    }
-
-    /// Set the SO_PIN_COUNT_LOW flag
-    pub fn set_so_pin_count_low(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_SO_PIN_COUNT_LOW, b);
-        self
-    }
-
-    /// Get the SO_PIN_FINAL_TRY flag
-    pub fn so_pin_final_try(&self) -> bool {
-        self.get_flag(CKF_SO_PIN_FINAL_TRY)
-    }
-
-    /// Set the SO_PIN_FINAL_TRY flag
-    pub fn set_so_pin_final_try(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_SO_PIN_FINAL_TRY, b);
-        self
-    }
-
-    /// Get the SO_PIN_LOCKED flag
-    pub fn so_pin_locked(&self) -> bool {
-        self.get_flag(CKF_SO_PIN_LOCKED)
-    }
-
-    /// Set the SO_PIN_LOCKED flag
-    pub fn set_so_pin_locked(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_SO_PIN_LOCKED, b);
-        self
-    }
-
-    /// Get the SO_PIN_TO_BE_CHANGED flag
-    pub fn so_pin_to_be_changed(&self) -> bool {
-        self.get_flag(CKF_SO_PIN_TO_BE_CHANGED)
-    }
-
-    /// Set the SO_PIN_TO_BE_CHANGED flag
-    pub fn set_so_pin_to_be_changed(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_SO_PIN_TO_BE_CHANGED, b);
-        self
-    }
-
-    /// Get the RW_SESSION flag
-    pub fn rw_session(&self) -> bool {
-        self.get_flag(CKF_RW_SESSION)
-    }
-
-    /// Set the RW_SESSION flag
-    pub fn set_rw_session(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_RW_SESSION, b);
-        self
-    }
-
-    /// Get the SERIAL_SESSION flag
-    pub fn serial_session(&self) -> bool {
-        self.get_flag(CKF_SERIAL_SESSION)
-    }
-
-    /// Set the SERIAL_SESSION flag
-    pub fn set_serial_session(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_SERIAL_SESSION, b);
-        self
-    }
-
-    /// Get the NEXT_OTP flag
-    pub fn next_otp(&self) -> bool {
-        self.get_flag(CKF_NEXT_OTP)
-    }
-
-    /// Set the NEXT_OTP flag
-    pub fn set_next_otp(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_NEXT_OTP, b);
-        self
-    }
-
-    /// Get the EXCLUDE_TIME flag
-    pub fn exclude_time(&self) -> bool {
-        self.get_flag(CKF_EXCLUDE_TIME)
-    }
-
-    /// Set the EXCLUDE_TIME flag
-    pub fn set_exclude_time(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_EXCLUDE_TIME, b);
-        self
-    }
-
-    /// Get the EXCLUDE_COUNTER flag
-    pub fn exclude_counter(&self) -> bool {
-        self.get_flag(CKF_EXCLUDE_COUNTER)
-    }
-
-    /// Set the EXCLUDE_COUNTER flag
-    pub fn set_exclude_counter(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_EXCLUDE_COUNTER, b);
-        self
-    }
-
-    /// Get the EXCLUDE_CHALLENGE flag
-    pub fn exclude_challenge(&self) -> bool {
-        self.get_flag(CKF_EXCLUDE_CHALLENGE)
-    }
-
-    /// Set the EXCLUDE_CHALLENGE flag
-    pub fn set_exclude_challenge(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_EXCLUDE_CHALLENGE, b);
-        self
-    }
-
-    /// Get the EXCLUDE_PIN flag
-    pub fn exclude_pin(&self) -> bool {
-        self.get_flag(CKF_EXCLUDE_PIN)
-    }
-
-    /// Set the EXCLUDE_PIN flag
-    pub fn set_exclude_pin(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_EXCLUDE_PIN, b);
-        self
-    }
-
-    /// Get the USER_FRIENDLY_OTP flag
-    pub fn user_friendly_otp(&self) -> bool {
-        self.get_flag(CKF_USER_FRIENDLY_OTP)
-    }
-
-    /// Set the USER_FRIENDLY_OTP flag
-    pub fn set_user_friendly_otp(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_USER_FRIENDLY_OTP, b);
-        self
-    }
-
-    /// Get the HW flag
-    pub fn hw(&self) -> bool {
-        self.get_flag(CKF_HW)
-    }
-
-    /// Set the HW flag
-    pub fn set_hw(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_HW, b);
-        self
-    }
-
-    /// Get the ENCRYPT flag
-    pub fn encrypt(&self) -> bool {
-        self.get_flag(CKF_ENCRYPT)
-    }
-
-    /// Set the ENCRYPT flag
-    pub fn set_encrypt(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_ENCRYPT, b);
-        self
-    }
-
-    /// Get the DECRYPT flag
-    pub fn decrypt(&self) -> bool {
-        self.get_flag(CKF_DECRYPT)
-    }
-
-    /// Set the DECRYPT flag
-    pub fn set_decrypt(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_DECRYPT, b);
-        self
-    }
-
-    /// Get the DIGEST flag
-    pub fn digest(&self) -> bool {
-        self.get_flag(CKF_DIGEST)
-    }
-
-    /// Set the DIGEST flag
-    pub fn set_digest(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_DIGEST, b);
-        self
-    }
-
-    /// Get the SIGN flag
-    pub fn sign(&self) -> bool {
-        self.get_flag(CKF_SIGN)
-    }
-
-    /// Set the SIGN flag
-    pub fn set_sign(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_SIGN, b);
-        self
-    }
-
-    /// Get the SIGN_RECOVER flag
-    pub fn sign_recover(&self) -> bool {
-        self.get_flag(CKF_SIGN_RECOVER)
-    }
-
-    /// Set the SIGN_RECOVER flag
-    pub fn set_sign_recover(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_SIGN_RECOVER, b);
-        self
-    }
-
-    /// Get the VERIFY flag
-    pub fn verify(&self) -> bool {
-        self.get_flag(CKF_VERIFY)
-    }
-
-    /// Set the VERIFY flag
-    pub fn set_verify(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_VERIFY, b);
-        self
-    }
-
-    /// Get the VERIFY_RECOVER flag
-    pub fn verify_recover(&self) -> bool {
-        self.get_flag(CKF_VERIFY_RECOVER)
-    }
-
-    /// Set the VERIFY_RECOVER flag
-    pub fn set_verify_recover(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_VERIFY_RECOVER, b);
-        self
-    }
-
-    /// Get the GENERATE flag
-    pub fn generate(&self) -> bool {
-        self.get_flag(CKF_GENERATE)
-    }
-
-    /// Set the GENERATE flag
-    pub fn set_generate(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_GENERATE, b);
-        self
-    }
-
-    /// Get the GENERATE_KEY_PAIR flag
-    pub fn generate_key_pair(&self) -> bool {
-        self.get_flag(CKF_GENERATE_KEY_PAIR)
-    }
-
-    /// Set the GENERATE_KEY_PAIR flag
-    pub fn set_generate_key_pair(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_GENERATE_KEY_PAIR, b);
-        self
-    }
-
-    /// Get the WRAP flag
-    pub fn wrap(&self) -> bool {
-        self.get_flag(CKF_WRAP)
-    }
-
-    /// Set the WRAP flag
-    pub fn set_wrap(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_WRAP, b);
-        self
-    }
-
-    /// Get the UNWRAP flag
-    pub fn unwrap(&self) -> bool {
-        self.get_flag(CKF_UNWRAP)
-    }
-
-    /// Set the UNWRAP flag
-    pub fn set_unwrap(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_UNWRAP, b);
-        self
-    }
-
-    /// Get the DERIVE flag
-    pub fn derive(&self) -> bool {
-        self.get_flag(CKF_DERIVE)
-    }
-
-    /// Set the DERIVE flag
-    pub fn set_derive(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_DERIVE, b);
-        self
-    }
-
-    /// Get the EXTENSION flag
-    pub fn extension(&self) -> bool {
-        self.get_flag(CKF_EXTENSION)
-    }
-
-    /// Set the EXTENSION flag
-    pub fn set_extension(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_EXTENSION, b);
-        self
-    }
-
-    /// Get the EC_F_P flag
-    pub fn ec_f_p(&self) -> bool {
-        self.get_flag(CKF_EC_F_P)
-    }
-
-    /// Set the EC_F_P flag
-    pub fn set_ec_f_p(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_EC_F_P, b);
-        self
-    }
-
-    /// Get the EC_NAMEDCURVE flag
-    pub fn ec_namedcurve(&self) -> bool {
-        self.get_flag(CKF_EC_NAMEDCURVE)
-    }
-
-    /// Set the EC_NAMEDCURVE flag
-    pub fn set_ec_namedcurve(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_EC_NAMEDCURVE, b);
-        self
-    }
-
-    /// Get the EC_UNCOMPRESS flag
-    pub fn ec_uncompress(&self) -> bool {
-        self.get_flag(CKF_EC_UNCOMPRESS)
-    }
-
-    /// Set the EC_UNCOMPRESS flag
-    pub fn set_ec_uncompress(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_EC_UNCOMPRESS, b);
-        self
-    }
-
-    /// Get the EC_COMPRESS flag
-    pub fn ec_compress(&self) -> bool {
-        self.get_flag(CKF_EC_COMPRESS)
-    }
-
-    /// Set the EC_COMPRESS flag
-    pub fn set_ec_compress(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_EC_COMPRESS, b);
-        self
-    }
-
-    /// Get the DONT_BLOCK flag
-    pub fn dont_block(&self) -> bool {
-        self.get_flag(CKF_DONT_BLOCK)
-    }
-
-    /// Set the DONT_BLOCK flag
-    pub fn set_dont_block(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_DONT_BLOCK, b);
-        self
-    }
-
-    /// Get the LIBRARY_CANT_CREATE_OS_THREADS flag
+    fn stringify_flag(flag: CK_FLAGS) -> &'static str {
+        match flag {
+            CKF_LIBRARY_CANT_CREATE_OS_THREADS => {
+                std::stringify!(CKF_LIBRARY_CANT_CREATE_OS_THREADS)
+            }
+            CKF_OS_LOCKING_OK => std::stringify!(CKF_OS_LOCKING_OK),
+            _ => "Unknown CK_C_INITIALIZE_ARGS flag",
+        }
+    }
+}
+
+impl InitializeFlags {
+    /// Creates a new instance of `InitializeFlags` with no flags set
+    pub fn new() -> Self {
+        InitializeFlags::default()
+    }
+
+    /// Gets value of [`CKF_LIBRARY_CANT_CREATE_OS_THREADS`]
     pub fn library_cant_create_os_threads(&self) -> bool {
         self.get_flag(CKF_LIBRARY_CANT_CREATE_OS_THREADS)
     }
 
-    /// Set the LIBRARY_CANT_CREATE_OS_THREADS flag
+    /// Sets value of [`CKF_LIBRARY_CANT_CREATE_OS_THREADS`]
     pub fn set_library_cant_create_os_threads(&mut self, b: bool) -> &mut Self {
         self.set_flag(CKF_LIBRARY_CANT_CREATE_OS_THREADS, b);
         self
     }
 
-    /// Get the OS_LOCKING_OK flag
+    /// Gets value of [`CKF_OS_LOCKING_OK`]
     pub fn os_locking_ok(&self) -> bool {
         self.get_flag(CKF_OS_LOCKING_OK)
     }
 
-    /// Set the OS_LOCKING_OK flag
+    /// Sets value of [`CKF_OS_LOCKING_OK`]
     pub fn set_os_locking_ok(&mut self, b: bool) -> &mut Self {
         self.set_flag(CKF_OS_LOCKING_OK, b);
         self
     }
 }
 
-impl From<Flags> for CK_FLAGS {
-    fn from(flags: Flags) -> Self {
+impl std::fmt::Display for InitializeFlags {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let flags = vec![CKF_LIBRARY_CANT_CREATE_OS_THREADS, CKF_OS_LOCKING_OK];
+        self.stringify_fmt(f, flags)
+    }
+}
+
+impl From<InitializeFlags> for CK_FLAGS {
+    fn from(flags: InitializeFlags) -> Self {
         flags.flags
     }
 }
 
-impl From<CK_FLAGS> for Flags {
+impl From<CK_FLAGS> for InitializeFlags {
+    fn from(flags: CK_FLAGS) -> Self {
+        Self { flags }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+/// Collection of flags defined for [`CK_SLOT_INFO`]
+pub struct MechanismFlags {
+    flags: CK_FLAGS,
+}
+
+impl Flags for MechanismFlags {
+    type FlagType = CK_FLAGS;
+
+    fn get_flag_value(&self) -> Self::FlagType {
+        self.flags
+    }
+
+    fn get_flag(&self, flag: Self::FlagType) -> bool {
+        self.get_flag_value() & flag == flag
+    }
+
+    fn set_flag(&mut self, flag: Self::FlagType, b: bool) {
+        if b {
+            self.flags |= flag;
+        } else {
+            self.flags &= !flag;
+        }
+    }
+
+    fn stringify_flag(flag: CK_FLAGS) -> &'static str {
+        match flag {
+            CKF_HW => std::stringify!(CKF_HW),
+            CKF_ENCRYPT => std::stringify!(CKF_ENCRYPT),
+            CKF_DECRYPT => std::stringify!(CKF_DECRYPT),
+            CKF_DIGEST => std::stringify!(CKF_DIGEST),
+            CKF_SIGN => std::stringify!(CKF_SIGN),
+            CKF_SIGN_RECOVER => std::stringify!(CKF_SIGN_RECOVER),
+            CKF_VERIFY => std::stringify!(CKF_VERIFY),
+            CKF_VERIFY_RECOVER => std::stringify!(CKF_VERIFY_RECOVER),
+            CKF_GENERATE => std::stringify!(CKF_GENERATE),
+            CKF_GENERATE_KEY_PAIR => std::stringify!(CKF_GENERATE_KEY_PAIR),
+            CKF_WRAP => std::stringify!(CKF_WRAP),
+            CKF_UNWRAP => std::stringify!(CKF_UNWRAP),
+            CKF_DERIVE => std::stringify!(CKF_DERIVE),
+            CKF_EXTENSION => std::stringify!(CKF_EXTENSION),
+            CKF_EC_F_P => std::stringify!(CKF_EC_F_P),
+            CKF_EC_NAMEDCURVE => std::stringify!(CKF_EC_NAMEDCURVE),
+            CKF_EC_UNCOMPRESS => std::stringify!(CKF_EC_UNCOMPRESS),
+            CKF_EC_COMPRESS => std::stringify!(CKF_EC_COMPRESS),
+            _ => "Unknown CK_MECHANISM_INFO flag",
+        }
+    }
+}
+
+impl MechanismFlags {
+    /// Creates a new instance of `MechanismFlags` with no flags set
+    pub fn new() -> Self {
+        MechanismFlags::default()
+    }
+
+    /// Gets value of [`CKF_HW`]
+    pub fn hardware(&self) -> bool {
+        self.get_flag(CKF_HW)
+    }
+
+    /// Sets value of [`CKF_HW`]
+    pub fn set_hardware(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_HW, b);
+        self
+    }
+
+    /// Gets value of [`CKF_ENCRYPT`]
+    pub fn encrypt(&self) -> bool {
+        self.get_flag(CKF_ENCRYPT)
+    }
+
+    /// Sets value of [`CKF_ENCRYPT`]
+    pub fn set_encrypt(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_ENCRYPT, b);
+        self
+    }
+
+    /// Gets value of [`CKF_DECRYPT`]
+    pub fn decrypt(&self) -> bool {
+        self.get_flag(CKF_DECRYPT)
+    }
+
+    /// Sets value of [`CKF_DECRYPT`]
+    pub fn set_decrypt(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_DECRYPT, b);
+        self
+    }
+
+    /// Gets value of [`CKF_DIGEST`]
+    pub fn digest(&self) -> bool {
+        self.get_flag(CKF_DIGEST)
+    }
+
+    /// Sets value of [`CKF_DIGEST`]
+    pub fn set_digest(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_DIGEST, b);
+        self
+    }
+
+    /// Gets value of [`CKF_SIGN`]
+    pub fn sign(&self) -> bool {
+        self.get_flag(CKF_SIGN)
+    }
+
+    /// Sets value of [`CKF_SIGN`]
+    pub fn set_sign(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_SIGN, b);
+        self
+    }
+
+    /// Gets value of [`CKF_SIGN_RECOVER`]
+    pub fn sign_recover(&self) -> bool {
+        self.get_flag(CKF_SIGN_RECOVER)
+    }
+
+    /// Sets value of [`CKF_SIGN_RECOVER`]
+    pub fn set_sign_recover(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_SIGN_RECOVER, b);
+        self
+    }
+
+    /// Gets value of [`CKF_VERIFY`]
+    pub fn verify(&self) -> bool {
+        self.get_flag(CKF_VERIFY)
+    }
+
+    /// Sets value of [`CKF_VERIFY`]
+    pub fn set_verify(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_VERIFY, b);
+        self
+    }
+
+    /// Gets value of [`CKF_VERIFY_RECOVER`]
+    pub fn verify_recover(&self) -> bool {
+        self.get_flag(CKF_VERIFY_RECOVER)
+    }
+
+    /// Sets value of [`CKF_VERIFY_RECOVER`]
+    pub fn set_verify_recover(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_VERIFY_RECOVER, b);
+        self
+    }
+
+    /// Gets value of [`CKF_GENERATE`]
+    pub fn generate(&self) -> bool {
+        self.get_flag(CKF_GENERATE)
+    }
+
+    /// Sets value of [`CKF_GENERATE`]
+    pub fn set_generate(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_GENERATE, b);
+        self
+    }
+
+    /// Gets value of [`CKF_GENERATE_KEY_PAIR`]
+    pub fn generate_key_pair(&self) -> bool {
+        self.get_flag(CKF_GENERATE_KEY_PAIR)
+    }
+
+    /// Sets value of [`CKF_GENERATE_KEY_PAIR`]
+    pub fn set_generate_key_pair(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_GENERATE_KEY_PAIR, b);
+        self
+    }
+
+    /// Gets value of [`CKF_WRAP`]
+    pub fn wrap(&self) -> bool {
+        self.get_flag(CKF_WRAP)
+    }
+
+    /// Sets value of [`CKF_WRAP`]
+    pub fn set_wrap(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_WRAP, b);
+        self
+    }
+
+    /// Gets value of [`CKF_UNWRAP`]
+    pub fn unwrap(&self) -> bool {
+        self.get_flag(CKF_UNWRAP)
+    }
+
+    /// Sets value of [`CKF_UNWRAP`]
+    pub fn set_unwrap(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_UNWRAP, b);
+        self
+    }
+
+    /// Gets value of [`CKF_DERIVE`]
+    pub fn derive(&self) -> bool {
+        self.get_flag(CKF_DERIVE)
+    }
+
+    /// Sets value of [`CKF_DERIVE`]
+    pub fn set_derive(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_DERIVE, b);
+        self
+    }
+
+    /// Gets value of [`CKF_EXTENSION`]
+    pub fn extension(&self) -> bool {
+        self.get_flag(CKF_EXTENSION)
+    }
+
+    /// Sets value of [`CKF_EXTENSION`]
+    pub fn set_extension(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_EXTENSION, b);
+        self
+    }
+
+    /// Gets value of [`CKF_EC_F_P`]
+    pub fn ec_f_p(&self) -> bool {
+        self.get_flag(CKF_EC_F_P)
+    }
+
+    /// Sets value of [`CKF_EC_F_P`]
+    pub fn set_ec_f_p(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_EC_F_P, b);
+        self
+    }
+
+    /// Gets value of [`CKF_EC_NAMEDCURVE`]
+    pub fn ec_namedcurve(&self) -> bool {
+        self.get_flag(CKF_EC_NAMEDCURVE)
+    }
+
+    /// Sets value of [`CKF_EC_NAMEDCURVE`]
+    pub fn set_ec_namedcurve(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_EC_NAMEDCURVE, b);
+        self
+    }
+
+    /// Gets value of [`CKF_EC_UNCOMPRESS`]
+    pub fn ec_uncompress(&self) -> bool {
+        self.get_flag(CKF_EC_UNCOMPRESS)
+    }
+
+    /// Sets value of [`CKF_EC_UNCOMPRESS`]
+    pub fn set_ec_uncompress(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_EC_UNCOMPRESS, b);
+        self
+    }
+
+    /// Gets value of [`CKF_EC_COMPRESS`]
+    pub fn ec_compress(&self) -> bool {
+        self.get_flag(CKF_EC_COMPRESS)
+    }
+
+    /// Sets value of [`CKF_EC_COMPRESS`]
+    pub fn set_ec_compress(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_EC_COMPRESS, b);
+        self
+    }
+}
+
+impl std::fmt::Display for MechanismFlags {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let flags = vec![
+            CKF_HW,
+            CKF_ENCRYPT,
+            CKF_DECRYPT,
+            CKF_DIGEST,
+            CKF_SIGN,
+            CKF_SIGN_RECOVER,
+            CKF_VERIFY,
+            CKF_VERIFY_RECOVER,
+            CKF_GENERATE,
+            CKF_GENERATE_KEY_PAIR,
+            CKF_WRAP,
+            CKF_UNWRAP,
+            CKF_DERIVE,
+            CKF_EXTENSION,
+            CKF_EC_F_P,
+            CKF_EC_NAMEDCURVE,
+            CKF_EC_UNCOMPRESS,
+            CKF_EC_COMPRESS,
+        ];
+        self.stringify_fmt(f, flags)
+    }
+}
+
+impl From<MechanismFlags> for CK_FLAGS {
+    fn from(flags: MechanismFlags) -> Self {
+        flags.flags
+    }
+}
+
+impl From<CK_FLAGS> for MechanismFlags {
+    fn from(flags: CK_FLAGS) -> Self {
+        Self { flags }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+/// Collection of flags defined for [`CK_SLOT_INFO`]
+pub struct SessionFlags {
+    flags: CK_FLAGS,
+}
+
+impl Flags for SessionFlags {
+    type FlagType = CK_FLAGS;
+
+    fn get_flag_value(&self) -> Self::FlagType {
+        self.flags
+    }
+
+    fn get_flag(&self, flag: Self::FlagType) -> bool {
+        self.get_flag_value() & flag == flag
+    }
+
+    fn set_flag(&mut self, flag: Self::FlagType, b: bool) {
+        if b {
+            self.flags |= flag;
+        } else {
+            self.flags &= !flag;
+        }
+    }
+
+    fn stringify_flag(flag: Self::FlagType) -> &'static str {
+        match flag {
+            CKF_RW_SESSION => std::stringify!(CKF_RW_SESSION),
+            CKF_SERIAL_SESSION => std::stringify!(CKF_SERIAL_SESSION),
+            _ => "Unknown session flag",
+        }
+    }
+}
+
+impl SessionFlags {
+    /// Creates a new instance of `SessionFlags` with no flags set
+    pub fn new() -> Self {
+        SessionFlags::default()
+    }
+
+    /// Gets value of [`CKF_RW_SESSION`]
+    pub fn rw_session(&self) -> bool {
+        self.get_flag(CKF_RW_SESSION)
+    }
+
+    /// Sets value of [`CKF_RW_SESSION`]
+    pub fn set_rw_session(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_RW_SESSION, b);
+        self
+    }
+
+    /// Gets value of [`CKF_SERIAL_SESSION`]
+    pub fn serial_session(&self) -> bool {
+        self.get_flag(CKF_SERIAL_SESSION)
+    }
+
+    /// Sets value of [`CKF_SERIAL_SESSION`]
+    pub fn set_serial_session(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_SERIAL_SESSION, b);
+        self
+    }
+}
+
+impl std::fmt::Display for SessionFlags {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let flags = vec![CKF_RW_SESSION, CKF_SERIAL_SESSION];
+        self.stringify_fmt(f, flags)
+    }
+}
+
+impl From<SessionFlags> for CK_FLAGS {
+    fn from(flags: SessionFlags) -> Self {
+        flags.flags
+    }
+}
+
+impl From<CK_FLAGS> for SessionFlags {
+    fn from(flags: CK_FLAGS) -> Self {
+        Self { flags }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+/// Collection of flags defined for [`CK_SLOT_INFO`]
+pub struct SlotFlags {
+    flags: CK_FLAGS,
+}
+
+impl Flags for SlotFlags {
+    type FlagType = CK_FLAGS;
+
+    fn get_flag_value(&self) -> Self::FlagType {
+        self.flags
+    }
+
+    fn get_flag(&self, flag: Self::FlagType) -> bool {
+        self.get_flag_value() & flag == flag
+    }
+
+    fn set_flag(&mut self, flag: Self::FlagType, b: bool) {
+        if b {
+            self.flags |= flag;
+        } else {
+            self.flags &= !flag;
+        }
+    }
+
+    fn stringify_flag(flag: Self::FlagType) -> &'static str {
+        match flag {
+            CKF_TOKEN_PRESENT => std::stringify!(CKF_TOKEN_PRESENT),
+            CKF_REMOVABLE_DEVICE => std::stringify!(CKF_REMOVABLE_DEVICE),
+            CKF_HW_SLOT => std::stringify!(CKF_HW_SLOT),
+            _ => "Unknown CK_SLOT_INFO flag",
+        }
+    }
+}
+
+impl SlotFlags {
+    /// Creates a new instance of `SlotFlags` with no flags set
+    pub fn new() -> Self {
+        SlotFlags::default()
+    }
+
+    /// Gets value of [`CKF_TOKEN_PRESENT`]
+    pub fn token_present(&self) -> bool {
+        self.get_flag(CKF_TOKEN_PRESENT)
+    }
+
+    /// Sets value of [`CKF_TOKEN_PRESENT`]
+    pub fn set_token_present(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_TOKEN_PRESENT, b);
+        self
+    }
+
+    /// Gets value of [`CKF_REMOVABLE_DEVICE`]
+    pub fn removable_device(&self) -> bool {
+        self.get_flag(CKF_REMOVABLE_DEVICE)
+    }
+
+    /// Sets value of [`CKF_REMOVABLE_DEVICE`]
+    pub fn set_removable_device(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_REMOVABLE_DEVICE, b);
+        self
+    }
+
+    /// Gets value of [`CKF_HW_SLOT`]
+    pub fn hardware_slot(&self) -> bool {
+        self.get_flag(CKF_HW_SLOT)
+    }
+
+    /// Sets value of [`CKF_HW_SLOT`]
+    pub fn set_hardware_slot(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_HW_SLOT, b);
+        self
+    }
+}
+
+impl std::fmt::Display for SlotFlags {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let flags = vec![CKF_TOKEN_PRESENT, CKF_REMOVABLE_DEVICE, CKF_HW_SLOT];
+        self.stringify_fmt(f, flags)
+    }
+}
+
+impl From<SlotFlags> for CK_FLAGS {
+    fn from(flags: SlotFlags) -> Self {
+        flags.flags
+    }
+}
+
+impl From<CK_FLAGS> for SlotFlags {
+    fn from(flags: CK_FLAGS) -> Self {
+        Self { flags }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+/// Collection of flags defined for [`CK_TOKEN_INFO`]
+pub struct TokenFlags {
+    flags: CK_FLAGS,
+}
+
+impl Flags for TokenFlags {
+    type FlagType = CK_FLAGS;
+
+    fn get_flag_value(&self) -> Self::FlagType {
+        self.flags
+    }
+
+    fn get_flag(&self, flag: Self::FlagType) -> bool {
+        self.get_flag_value() & flag == flag
+    }
+
+    fn set_flag(&mut self, flag: Self::FlagType, b: bool) {
+        if b {
+            self.flags |= flag;
+        } else {
+            self.flags &= !flag;
+        }
+    }
+
+    fn stringify_flag(flag: Self::FlagType) -> &'static str {
+        match flag {
+            CKF_RNG => std::stringify!(CKF_RNG),
+            CKF_WRITE_PROTECTED => std::stringify!(CKF_WRITE_PROTECTED),
+            CKF_LOGIN_REQUIRED => std::stringify!(CKF_LOGIN_REQUIRED),
+            CKF_USER_PIN_INITIALIZED => std::stringify!(CKF_USER_PIN_INITIALIZED),
+            CKF_RESTORE_KEY_NOT_NEEDED => std::stringify!(CKF_RESTORE_KEY_NOT_NEEDED),
+            CKF_CLOCK_ON_TOKEN => std::stringify!(CKF_CLOCK_ON_TOKEN),
+            CKF_PROTECTED_AUTHENTICATION_PATH => std::stringify!(CKF_PROTECTED_AUTHENTICATION_PATH),
+            CKF_DUAL_CRYPTO_OPERATIONS => std::stringify!(CKF_DUAL_CRYPTO_OPERATIONS),
+            CKF_TOKEN_INITIALIZED => std::stringify!(CKF_TOKEN_INITIALIZED),
+            CKF_SECONDARY_AUTHENTICATION => std::stringify!(CKF_SECONDARY_AUTHENTICATION),
+            CKF_USER_PIN_COUNT_LOW => std::stringify!(CKF_USER_PIN_COUNT_LOW),
+            CKF_USER_PIN_FINAL_TRY => std::stringify!(CKF_USER_PIN_FINAL_TRY),
+            CKF_USER_PIN_LOCKED => std::stringify!(CKF_USER_PIN_LOCKED),
+            CKF_USER_PIN_TO_BE_CHANGED => std::stringify!(CKF_USER_PIN_TO_BE_CHANGED),
+            CKF_SO_PIN_COUNT_LOW => std::stringify!(CKF_SO_PIN_COUNT_LOW),
+            CKF_SO_PIN_FINAL_TRY => std::stringify!(CKF_SO_PIN_FINAL_TRY),
+            CKF_SO_PIN_LOCKED => std::stringify!(CKF_SO_PIN_LOCKED),
+            CKF_SO_PIN_TO_BE_CHANGED => std::stringify!(CKF_SO_PIN_TO_BE_CHANGED),
+            _ => "Unknown CK_TOKEN_INFO flag",
+        }
+    }
+}
+
+impl TokenFlags {
+    /// Creates a new instance of `TokenFlags` with no flags set
+    pub fn new() -> Self {
+        TokenFlags::default()
+    }
+
+    /// Gets value of [`CKF_RNG`]
+    pub fn random_number_generator(&self) -> bool {
+        self.get_flag(CKF_RNG)
+    }
+
+    /// Sets value of [`CKF_RNG`]
+    pub fn set_random_number_generator(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_RNG, b);
+        self
+    }
+
+    /// Gets value of [`CKF_WRITE_PROTECTED`]
+    pub fn write_protected(&self) -> bool {
+        self.get_flag(CKF_WRITE_PROTECTED)
+    }
+
+    /// Sets value of [`CKF_WRITE_PROTECTED`]
+    pub fn set_write_protected(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_WRITE_PROTECTED, b);
+        self
+    }
+
+    /// Gets value of [`CKF_LOGIN_REQUIRED`]
+    pub fn login_required(&self) -> bool {
+        self.get_flag(CKF_LOGIN_REQUIRED)
+    }
+
+    /// Sets value of [`CKF_LOGIN_REQUIRED`]
+    pub fn set_login_required(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_LOGIN_REQUIRED, b);
+        self
+    }
+
+    /// Gets value of [`CKF_USER_PIN_INITIALIZED`]
+    pub fn user_pin_initialized(&self) -> bool {
+        self.get_flag(CKF_USER_PIN_INITIALIZED)
+    }
+
+    /// Sets value of [`CKF_USER_PIN_INITIALIZED`]
+    pub fn set_user_pin_initialized(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_USER_PIN_INITIALIZED, b);
+        self
+    }
+
+    /// Gets value of [`CKF_RESTORE_KEY_NOT_NEEDED`]
+    pub fn restore_key_not_needed(&self) -> bool {
+        self.get_flag(CKF_RESTORE_KEY_NOT_NEEDED)
+    }
+
+    /// Sets value of [`CKF_RESTORE_KEY_NOT_NEEDED`]
+    pub fn set_restore_key_not_needed(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_RESTORE_KEY_NOT_NEEDED, b);
+        self
+    }
+
+    /// Gets value of [`CKF_CLOCK_ON_TOKEN`]
+    pub fn clock_on_token(&self) -> bool {
+        self.get_flag(CKF_CLOCK_ON_TOKEN)
+    }
+
+    /// Sets value of [`CKF_CLOCK_ON_TOKEN`]
+    pub fn set_clock_on_token(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_CLOCK_ON_TOKEN, b);
+        self
+    }
+
+    /// Gets value of [`CKF_PROTECTED_AUTHENTICATION_PATH`]
+    pub fn protected_authentication_path(&self) -> bool {
+        self.get_flag(CKF_PROTECTED_AUTHENTICATION_PATH)
+    }
+
+    /// Sets value of [`CKF_PROTECTED_AUTHENTICATION_PATH`]
+    pub fn set_protected_authentication_path(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_PROTECTED_AUTHENTICATION_PATH, b);
+        self
+    }
+
+    /// Gets value of [`CKF_DUAL_CRYPTO_OPERATIONS`]
+    pub fn dual_crypto_operations(&self) -> bool {
+        self.get_flag(CKF_DUAL_CRYPTO_OPERATIONS)
+    }
+
+    /// Sets value of [`CKF_DUAL_CRYPTO_OPERATIONS`]
+    pub fn set_dual_crypto_operations(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_DUAL_CRYPTO_OPERATIONS, b);
+        self
+    }
+
+    /// Gets value of [`CKF_TOKEN_INITIALIZED`]
+    pub fn token_initialized(&self) -> bool {
+        self.get_flag(CKF_TOKEN_INITIALIZED)
+    }
+
+    /// Sets value of [`CKF_TOKEN_INITIALIZED`]
+    pub fn set_token_initialized(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_TOKEN_INITIALIZED, b);
+        self
+    }
+
+    /// Gets value of [`CKF_SECONDARY_AUTHENTICATION`]
+    pub fn secondary_authentication(&self) -> bool {
+        self.get_flag(CKF_SECONDARY_AUTHENTICATION)
+    }
+
+    /// Sets value of [`CKF_SECONDARY_AUTHENTICATION`]
+    pub fn set_secondary_authentication(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_SECONDARY_AUTHENTICATION, b);
+        self
+    }
+
+    /// Gets value of [`CKF_USER_PIN_COUNT_LOW`]
+    pub fn user_pin_count_low(&self) -> bool {
+        self.get_flag(CKF_USER_PIN_COUNT_LOW)
+    }
+
+    /// Sets value of [`CKF_USER_PIN_COUNT_LOW`]
+    pub fn set_user_pin_count_low(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_USER_PIN_COUNT_LOW, b);
+        self
+    }
+
+    /// Gets value of [`CKF_USER_PIN_FINAL_TRY`]
+    pub fn user_pin_final_try(&self) -> bool {
+        self.get_flag(CKF_USER_PIN_FINAL_TRY)
+    }
+
+    /// Sets value of [`CKF_USER_PIN_COUNT_LOW`]
+    pub fn set_user_pin_final_try(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_USER_PIN_COUNT_LOW, b);
+        self
+    }
+
+    /// Gets value of [`CKF_USER_PIN_LOCKED`]
+    pub fn user_pin_locked(&self) -> bool {
+        self.get_flag(CKF_USER_PIN_LOCKED)
+    }
+
+    /// Sets value of [`CKF_USER_PIN_LOCKED`]
+    pub fn set_user_pin_locked(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_USER_PIN_LOCKED, b);
+        self
+    }
+
+    /// Gets value of [`CKF_USER_PIN_TO_BE_CHANGED`]
+    pub fn user_pin_to_be_changed(&self) -> bool {
+        self.get_flag(CKF_USER_PIN_TO_BE_CHANGED)
+    }
+
+    /// Sets value of [`CKF_USER_PIN_TO_BE_CHANGED`]
+    pub fn set_user_pin_to_be_changed(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_USER_PIN_TO_BE_CHANGED, b);
+        self
+    }
+
+    /// Gets value of [`CKF_SO_PIN_COUNT_LOW`]
+    pub fn so_pin_count_low(&self) -> bool {
+        self.get_flag(CKF_SO_PIN_COUNT_LOW)
+    }
+
+    /// Sets value of [`CKF_SO_PIN_COUNT_LOW`]
+    pub fn set_so_pin_count_low(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_SO_PIN_COUNT_LOW, b);
+        self
+    }
+
+    /// Gets value of [`CKF_SO_PIN_FINAL_TRY`]
+    pub fn so_pin_final_try(&self) -> bool {
+        self.get_flag(CKF_SO_PIN_FINAL_TRY)
+    }
+
+    /// Sets value of [`CKF_SO_PIN_COUNT_LOW`]
+    pub fn set_so_pin_final_try(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_SO_PIN_COUNT_LOW, b);
+        self
+    }
+
+    /// Gets value of [`CKF_SO_PIN_LOCKED`]
+    pub fn so_pin_locked(&self) -> bool {
+        self.get_flag(CKF_SO_PIN_LOCKED)
+    }
+
+    /// Sets value of [`CKF_SO_PIN_LOCKED`]
+    pub fn set_so_pin_locked(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_SO_PIN_LOCKED, b);
+        self
+    }
+
+    /// Gets value of [`CKF_SO_PIN_TO_BE_CHANGED`]
+    pub fn so_pin_to_be_changed(&self) -> bool {
+        self.get_flag(CKF_SO_PIN_TO_BE_CHANGED)
+    }
+
+    /// Sets value of [`CKF_SO_PIN_TO_BE_CHANGED`]
+    pub fn set_so_pin_to_be_changed(&mut self, b: bool) -> &mut Self {
+        self.set_flag(CKF_SO_PIN_TO_BE_CHANGED, b);
+        self
+    }
+}
+
+impl std::fmt::Display for TokenFlags {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let flags = vec![
+            CKF_RNG,
+            CKF_WRITE_PROTECTED,
+            CKF_LOGIN_REQUIRED,
+            CKF_USER_PIN_INITIALIZED,
+            CKF_RESTORE_KEY_NOT_NEEDED,
+            CKF_CLOCK_ON_TOKEN,
+            CKF_PROTECTED_AUTHENTICATION_PATH,
+            CKF_DUAL_CRYPTO_OPERATIONS,
+            CKF_TOKEN_INITIALIZED,
+            CKF_SECONDARY_AUTHENTICATION,
+            CKF_USER_PIN_COUNT_LOW,
+            CKF_USER_PIN_FINAL_TRY,
+            CKF_USER_PIN_LOCKED,
+            CKF_USER_PIN_TO_BE_CHANGED,
+            CKF_SO_PIN_COUNT_LOW,
+            CKF_SO_PIN_FINAL_TRY,
+            CKF_SO_PIN_LOCKED,
+            CKF_SO_PIN_TO_BE_CHANGED,
+        ];
+        self.stringify_fmt(f, flags)
+    }
+}
+
+impl From<TokenFlags> for CK_FLAGS {
+    fn from(flags: TokenFlags) -> Self {
+        flags.flags
+    }
+}
+
+impl From<CK_FLAGS> for TokenFlags {
     fn from(flags: CK_FLAGS) -> Self {
         Self { flags }
     }
@@ -697,5 +972,105 @@ impl TryFrom<usize> for Ulong {
         Ok(Ulong {
             val: ulong.try_into()?,
         })
+    }
+}
+
+impl std::fmt::Display for Ulong {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.val)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+/// Represents a version
+pub struct Version {
+    major: CK_BYTE,
+    minor: CK_BYTE,
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+impl Version {
+    /// Returns the major version
+    pub fn get_major(&self) -> CK_BYTE {
+        self.major
+    }
+
+    /// Returns the minor version
+    pub fn get_minor(&self) -> CK_BYTE {
+        self.minor
+    }
+}
+
+impl From<Version> for CK_VERSION {
+    fn from(version: Version) -> Self {
+        CK_VERSION {
+            major: version.major,
+            minor: version.minor,
+        }
+    }
+}
+
+impl From<CK_VERSION> for Version {
+    fn from(version: CK_VERSION) -> Self {
+        Version {
+            major: version.major,
+            minor: version.minor,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+/// Type identifying the PKCS#11 library information
+pub struct Info {
+    val: CK_INFO,
+}
+
+impl Info {
+    pub(crate) fn new(val: CK_INFO) -> Self {
+        Self { val }
+    }
+
+    /// Returns the version of Cryptoki that the library is compatible with
+    pub fn get_cryptoki_version(&self) -> Version {
+        self.val.cryptokiVersion.into()
+    }
+
+    /// Returns the flags of the library (should be zero!)
+    pub fn get_flags(&self) -> CK_FLAGS {
+        self.val.flags
+    }
+
+    /// Returns the description of the library
+    pub fn get_library_description(&self) -> String {
+        str_from_blank_padded(&self.val.libraryDescription)
+    }
+
+    /// Returns the version of the library
+    pub fn get_library_version(&self) -> Version {
+        self.val.libraryVersion.into()
+    }
+
+    /// Returns the manufacturer of the library
+    pub fn get_manufacturer_id(&self) -> String {
+        str_from_blank_padded(&self.val.manufacturerID)
+    }
+}
+
+impl Deref for Info {
+    type Target = CK_INFO;
+
+    fn deref(&self) -> &Self::Target {
+        &self.val
+    }
+}
+
+impl From<Info> for CK_INFO {
+    fn from(info: Info) -> Self {
+        *info
     }
 }

--- a/cryptoki/src/types/mod.rs
+++ b/cryptoki/src/types/mod.rs
@@ -44,7 +44,7 @@ trait Flags: std::fmt::Display {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-/// Collection of flags defined for [`CK_SLOT_INFO`]
+/// Collection of flags defined for [`CK_C_INITIALIZE_ARGS`]
 pub struct InitializeFlags {
     flags: CK_FLAGS,
 }
@@ -128,7 +128,7 @@ impl From<CK_FLAGS> for InitializeFlags {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-/// Collection of flags defined for [`CK_SLOT_INFO`]
+/// Collection of flags defined for [`CK_MECHANISM_INFO`]
 pub struct MechanismFlags {
     flags: CK_FLAGS,
 }
@@ -421,7 +421,7 @@ impl From<CK_FLAGS> for MechanismFlags {
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-/// Collection of flags defined for [`CK_SLOT_INFO`]
+/// Collection of flags defined for [`CK_SESSION_INFO`]
 pub struct SessionFlags {
     flags: CK_FLAGS,
 }

--- a/cryptoki/src/types/mod.rs
+++ b/cryptoki/src/types/mod.rs
@@ -778,9 +778,9 @@ impl TokenFlags {
         self.get_flag(CKF_USER_PIN_FINAL_TRY)
     }
 
-    /// Sets value of [`CKF_USER_PIN_COUNT_LOW`]
+    /// Sets value of [`CKF_USER_PIN_FINAL_TRY`]
     pub fn set_user_pin_final_try(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_USER_PIN_COUNT_LOW, b);
+        self.set_flag(CKF_USER_PIN_FINAL_TRY, b);
         self
     }
 
@@ -822,9 +822,9 @@ impl TokenFlags {
         self.get_flag(CKF_SO_PIN_FINAL_TRY)
     }
 
-    /// Sets value of [`CKF_SO_PIN_COUNT_LOW`]
+    /// Sets value of [`CKF_SO_PIN_FINAL_TRY`]
     pub fn set_so_pin_final_try(&mut self, b: bool) -> &mut Self {
-        self.set_flag(CKF_SO_PIN_COUNT_LOW, b);
+        self.set_flag(CKF_SO_PIN_FINAL_TRY, b);
         self
     }
 

--- a/cryptoki/src/types/mod.rs
+++ b/cryptoki/src/types/mod.rs
@@ -9,7 +9,7 @@ pub mod object;
 pub mod session;
 pub mod slot_token;
 
-use crate::{str_from_blank_padded, Error, Result};
+use crate::{string_from_blank_padded, Error, Result};
 use cryptoki_sys::*;
 use log::error;
 use std::convert::TryFrom;
@@ -20,9 +20,9 @@ use std::ops::Deref;
 trait Flags: std::fmt::Display {
     type FlagType: Copy;
 
-    fn get_flag_value(&self) -> Self::FlagType;
+    fn flag_value(&self) -> Self::FlagType;
 
-    fn get_flag(&self, flag: Self::FlagType) -> bool;
+    fn flag(&self, flag: Self::FlagType) -> bool;
 
     fn set_flag(&mut self, flag: Self::FlagType, b: bool);
 
@@ -31,7 +31,7 @@ trait Flags: std::fmt::Display {
     fn stringify_fmt(&self, f: &mut Formatter<'_>, flags: Vec<Self::FlagType>) -> std::fmt::Result {
         let mut first_done = false;
         for flag in flags.iter() {
-            if self.get_flag(*flag) {
+            if self.flag(*flag) {
                 if first_done {
                     write!(f, ", ")?;
                 }
@@ -52,12 +52,12 @@ pub struct InitializeFlags {
 impl Flags for InitializeFlags {
     type FlagType = CK_FLAGS;
 
-    fn get_flag_value(&self) -> Self::FlagType {
+    fn flag_value(&self) -> Self::FlagType {
         self.flags
     }
 
-    fn get_flag(&self, flag: Self::FlagType) -> bool {
-        self.get_flag_value() & flag == flag
+    fn flag(&self, flag: Self::FlagType) -> bool {
+        self.flag_value() & flag == flag
     }
 
     fn set_flag(&mut self, flag: Self::FlagType, b: bool) {
@@ -87,7 +87,7 @@ impl InitializeFlags {
 
     /// Gets value of [`CKF_LIBRARY_CANT_CREATE_OS_THREADS`]
     pub fn library_cant_create_os_threads(&self) -> bool {
-        self.get_flag(CKF_LIBRARY_CANT_CREATE_OS_THREADS)
+        self.flag(CKF_LIBRARY_CANT_CREATE_OS_THREADS)
     }
 
     /// Sets value of [`CKF_LIBRARY_CANT_CREATE_OS_THREADS`]
@@ -98,7 +98,7 @@ impl InitializeFlags {
 
     /// Gets value of [`CKF_OS_LOCKING_OK`]
     pub fn os_locking_ok(&self) -> bool {
-        self.get_flag(CKF_OS_LOCKING_OK)
+        self.flag(CKF_OS_LOCKING_OK)
     }
 
     /// Sets value of [`CKF_OS_LOCKING_OK`]
@@ -136,12 +136,12 @@ pub struct MechanismFlags {
 impl Flags for MechanismFlags {
     type FlagType = CK_FLAGS;
 
-    fn get_flag_value(&self) -> Self::FlagType {
+    fn flag_value(&self) -> Self::FlagType {
         self.flags
     }
 
-    fn get_flag(&self, flag: Self::FlagType) -> bool {
-        self.get_flag_value() & flag == flag
+    fn flag(&self, flag: Self::FlagType) -> bool {
+        self.flag_value() & flag == flag
     }
 
     fn set_flag(&mut self, flag: Self::FlagType, b: bool) {
@@ -185,7 +185,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_HW`]
     pub fn hardware(&self) -> bool {
-        self.get_flag(CKF_HW)
+        self.flag(CKF_HW)
     }
 
     /// Sets value of [`CKF_HW`]
@@ -196,7 +196,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_ENCRYPT`]
     pub fn encrypt(&self) -> bool {
-        self.get_flag(CKF_ENCRYPT)
+        self.flag(CKF_ENCRYPT)
     }
 
     /// Sets value of [`CKF_ENCRYPT`]
@@ -207,7 +207,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_DECRYPT`]
     pub fn decrypt(&self) -> bool {
-        self.get_flag(CKF_DECRYPT)
+        self.flag(CKF_DECRYPT)
     }
 
     /// Sets value of [`CKF_DECRYPT`]
@@ -218,7 +218,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_DIGEST`]
     pub fn digest(&self) -> bool {
-        self.get_flag(CKF_DIGEST)
+        self.flag(CKF_DIGEST)
     }
 
     /// Sets value of [`CKF_DIGEST`]
@@ -229,7 +229,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_SIGN`]
     pub fn sign(&self) -> bool {
-        self.get_flag(CKF_SIGN)
+        self.flag(CKF_SIGN)
     }
 
     /// Sets value of [`CKF_SIGN`]
@@ -240,7 +240,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_SIGN_RECOVER`]
     pub fn sign_recover(&self) -> bool {
-        self.get_flag(CKF_SIGN_RECOVER)
+        self.flag(CKF_SIGN_RECOVER)
     }
 
     /// Sets value of [`CKF_SIGN_RECOVER`]
@@ -251,7 +251,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_VERIFY`]
     pub fn verify(&self) -> bool {
-        self.get_flag(CKF_VERIFY)
+        self.flag(CKF_VERIFY)
     }
 
     /// Sets value of [`CKF_VERIFY`]
@@ -262,7 +262,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_VERIFY_RECOVER`]
     pub fn verify_recover(&self) -> bool {
-        self.get_flag(CKF_VERIFY_RECOVER)
+        self.flag(CKF_VERIFY_RECOVER)
     }
 
     /// Sets value of [`CKF_VERIFY_RECOVER`]
@@ -273,7 +273,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_GENERATE`]
     pub fn generate(&self) -> bool {
-        self.get_flag(CKF_GENERATE)
+        self.flag(CKF_GENERATE)
     }
 
     /// Sets value of [`CKF_GENERATE`]
@@ -284,7 +284,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_GENERATE_KEY_PAIR`]
     pub fn generate_key_pair(&self) -> bool {
-        self.get_flag(CKF_GENERATE_KEY_PAIR)
+        self.flag(CKF_GENERATE_KEY_PAIR)
     }
 
     /// Sets value of [`CKF_GENERATE_KEY_PAIR`]
@@ -295,7 +295,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_WRAP`]
     pub fn wrap(&self) -> bool {
-        self.get_flag(CKF_WRAP)
+        self.flag(CKF_WRAP)
     }
 
     /// Sets value of [`CKF_WRAP`]
@@ -306,7 +306,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_UNWRAP`]
     pub fn unwrap(&self) -> bool {
-        self.get_flag(CKF_UNWRAP)
+        self.flag(CKF_UNWRAP)
     }
 
     /// Sets value of [`CKF_UNWRAP`]
@@ -317,7 +317,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_DERIVE`]
     pub fn derive(&self) -> bool {
-        self.get_flag(CKF_DERIVE)
+        self.flag(CKF_DERIVE)
     }
 
     /// Sets value of [`CKF_DERIVE`]
@@ -328,7 +328,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_EXTENSION`]
     pub fn extension(&self) -> bool {
-        self.get_flag(CKF_EXTENSION)
+        self.flag(CKF_EXTENSION)
     }
 
     /// Sets value of [`CKF_EXTENSION`]
@@ -339,7 +339,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_EC_F_P`]
     pub fn ec_f_p(&self) -> bool {
-        self.get_flag(CKF_EC_F_P)
+        self.flag(CKF_EC_F_P)
     }
 
     /// Sets value of [`CKF_EC_F_P`]
@@ -350,7 +350,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_EC_NAMEDCURVE`]
     pub fn ec_namedcurve(&self) -> bool {
-        self.get_flag(CKF_EC_NAMEDCURVE)
+        self.flag(CKF_EC_NAMEDCURVE)
     }
 
     /// Sets value of [`CKF_EC_NAMEDCURVE`]
@@ -361,7 +361,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_EC_UNCOMPRESS`]
     pub fn ec_uncompress(&self) -> bool {
-        self.get_flag(CKF_EC_UNCOMPRESS)
+        self.flag(CKF_EC_UNCOMPRESS)
     }
 
     /// Sets value of [`CKF_EC_UNCOMPRESS`]
@@ -372,7 +372,7 @@ impl MechanismFlags {
 
     /// Gets value of [`CKF_EC_COMPRESS`]
     pub fn ec_compress(&self) -> bool {
-        self.get_flag(CKF_EC_COMPRESS)
+        self.flag(CKF_EC_COMPRESS)
     }
 
     /// Sets value of [`CKF_EC_COMPRESS`]
@@ -429,12 +429,12 @@ pub struct SessionFlags {
 impl Flags for SessionFlags {
     type FlagType = CK_FLAGS;
 
-    fn get_flag_value(&self) -> Self::FlagType {
+    fn flag_value(&self) -> Self::FlagType {
         self.flags
     }
 
-    fn get_flag(&self, flag: Self::FlagType) -> bool {
-        self.get_flag_value() & flag == flag
+    fn flag(&self, flag: Self::FlagType) -> bool {
+        self.flag_value() & flag == flag
     }
 
     fn set_flag(&mut self, flag: Self::FlagType, b: bool) {
@@ -462,7 +462,7 @@ impl SessionFlags {
 
     /// Gets value of [`CKF_RW_SESSION`]
     pub fn rw_session(&self) -> bool {
-        self.get_flag(CKF_RW_SESSION)
+        self.flag(CKF_RW_SESSION)
     }
 
     /// Sets value of [`CKF_RW_SESSION`]
@@ -473,7 +473,7 @@ impl SessionFlags {
 
     /// Gets value of [`CKF_SERIAL_SESSION`]
     pub fn serial_session(&self) -> bool {
-        self.get_flag(CKF_SERIAL_SESSION)
+        self.flag(CKF_SERIAL_SESSION)
     }
 
     /// Sets value of [`CKF_SERIAL_SESSION`]
@@ -511,12 +511,12 @@ pub struct SlotFlags {
 impl Flags for SlotFlags {
     type FlagType = CK_FLAGS;
 
-    fn get_flag_value(&self) -> Self::FlagType {
+    fn flag_value(&self) -> Self::FlagType {
         self.flags
     }
 
-    fn get_flag(&self, flag: Self::FlagType) -> bool {
-        self.get_flag_value() & flag == flag
+    fn flag(&self, flag: Self::FlagType) -> bool {
+        self.flag_value() & flag == flag
     }
 
     fn set_flag(&mut self, flag: Self::FlagType, b: bool) {
@@ -545,7 +545,7 @@ impl SlotFlags {
 
     /// Gets value of [`CKF_TOKEN_PRESENT`]
     pub fn token_present(&self) -> bool {
-        self.get_flag(CKF_TOKEN_PRESENT)
+        self.flag(CKF_TOKEN_PRESENT)
     }
 
     /// Sets value of [`CKF_TOKEN_PRESENT`]
@@ -556,7 +556,7 @@ impl SlotFlags {
 
     /// Gets value of [`CKF_REMOVABLE_DEVICE`]
     pub fn removable_device(&self) -> bool {
-        self.get_flag(CKF_REMOVABLE_DEVICE)
+        self.flag(CKF_REMOVABLE_DEVICE)
     }
 
     /// Sets value of [`CKF_REMOVABLE_DEVICE`]
@@ -567,7 +567,7 @@ impl SlotFlags {
 
     /// Gets value of [`CKF_HW_SLOT`]
     pub fn hardware_slot(&self) -> bool {
-        self.get_flag(CKF_HW_SLOT)
+        self.flag(CKF_HW_SLOT)
     }
 
     /// Sets value of [`CKF_HW_SLOT`]
@@ -605,12 +605,12 @@ pub struct TokenFlags {
 impl Flags for TokenFlags {
     type FlagType = CK_FLAGS;
 
-    fn get_flag_value(&self) -> Self::FlagType {
+    fn flag_value(&self) -> Self::FlagType {
         self.flags
     }
 
-    fn get_flag(&self, flag: Self::FlagType) -> bool {
-        self.get_flag_value() & flag == flag
+    fn flag(&self, flag: Self::FlagType) -> bool {
+        self.flag_value() & flag == flag
     }
 
     fn set_flag(&mut self, flag: Self::FlagType, b: bool) {
@@ -654,7 +654,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_RNG`]
     pub fn random_number_generator(&self) -> bool {
-        self.get_flag(CKF_RNG)
+        self.flag(CKF_RNG)
     }
 
     /// Sets value of [`CKF_RNG`]
@@ -665,7 +665,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_WRITE_PROTECTED`]
     pub fn write_protected(&self) -> bool {
-        self.get_flag(CKF_WRITE_PROTECTED)
+        self.flag(CKF_WRITE_PROTECTED)
     }
 
     /// Sets value of [`CKF_WRITE_PROTECTED`]
@@ -676,7 +676,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_LOGIN_REQUIRED`]
     pub fn login_required(&self) -> bool {
-        self.get_flag(CKF_LOGIN_REQUIRED)
+        self.flag(CKF_LOGIN_REQUIRED)
     }
 
     /// Sets value of [`CKF_LOGIN_REQUIRED`]
@@ -687,7 +687,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_USER_PIN_INITIALIZED`]
     pub fn user_pin_initialized(&self) -> bool {
-        self.get_flag(CKF_USER_PIN_INITIALIZED)
+        self.flag(CKF_USER_PIN_INITIALIZED)
     }
 
     /// Sets value of [`CKF_USER_PIN_INITIALIZED`]
@@ -698,7 +698,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_RESTORE_KEY_NOT_NEEDED`]
     pub fn restore_key_not_needed(&self) -> bool {
-        self.get_flag(CKF_RESTORE_KEY_NOT_NEEDED)
+        self.flag(CKF_RESTORE_KEY_NOT_NEEDED)
     }
 
     /// Sets value of [`CKF_RESTORE_KEY_NOT_NEEDED`]
@@ -709,7 +709,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_CLOCK_ON_TOKEN`]
     pub fn clock_on_token(&self) -> bool {
-        self.get_flag(CKF_CLOCK_ON_TOKEN)
+        self.flag(CKF_CLOCK_ON_TOKEN)
     }
 
     /// Sets value of [`CKF_CLOCK_ON_TOKEN`]
@@ -720,7 +720,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_PROTECTED_AUTHENTICATION_PATH`]
     pub fn protected_authentication_path(&self) -> bool {
-        self.get_flag(CKF_PROTECTED_AUTHENTICATION_PATH)
+        self.flag(CKF_PROTECTED_AUTHENTICATION_PATH)
     }
 
     /// Sets value of [`CKF_PROTECTED_AUTHENTICATION_PATH`]
@@ -731,7 +731,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_DUAL_CRYPTO_OPERATIONS`]
     pub fn dual_crypto_operations(&self) -> bool {
-        self.get_flag(CKF_DUAL_CRYPTO_OPERATIONS)
+        self.flag(CKF_DUAL_CRYPTO_OPERATIONS)
     }
 
     /// Sets value of [`CKF_DUAL_CRYPTO_OPERATIONS`]
@@ -742,7 +742,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_TOKEN_INITIALIZED`]
     pub fn token_initialized(&self) -> bool {
-        self.get_flag(CKF_TOKEN_INITIALIZED)
+        self.flag(CKF_TOKEN_INITIALIZED)
     }
 
     /// Sets value of [`CKF_TOKEN_INITIALIZED`]
@@ -753,7 +753,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_SECONDARY_AUTHENTICATION`]
     pub fn secondary_authentication(&self) -> bool {
-        self.get_flag(CKF_SECONDARY_AUTHENTICATION)
+        self.flag(CKF_SECONDARY_AUTHENTICATION)
     }
 
     /// Sets value of [`CKF_SECONDARY_AUTHENTICATION`]
@@ -764,7 +764,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_USER_PIN_COUNT_LOW`]
     pub fn user_pin_count_low(&self) -> bool {
-        self.get_flag(CKF_USER_PIN_COUNT_LOW)
+        self.flag(CKF_USER_PIN_COUNT_LOW)
     }
 
     /// Sets value of [`CKF_USER_PIN_COUNT_LOW`]
@@ -775,7 +775,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_USER_PIN_FINAL_TRY`]
     pub fn user_pin_final_try(&self) -> bool {
-        self.get_flag(CKF_USER_PIN_FINAL_TRY)
+        self.flag(CKF_USER_PIN_FINAL_TRY)
     }
 
     /// Sets value of [`CKF_USER_PIN_FINAL_TRY`]
@@ -786,7 +786,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_USER_PIN_LOCKED`]
     pub fn user_pin_locked(&self) -> bool {
-        self.get_flag(CKF_USER_PIN_LOCKED)
+        self.flag(CKF_USER_PIN_LOCKED)
     }
 
     /// Sets value of [`CKF_USER_PIN_LOCKED`]
@@ -797,7 +797,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_USER_PIN_TO_BE_CHANGED`]
     pub fn user_pin_to_be_changed(&self) -> bool {
-        self.get_flag(CKF_USER_PIN_TO_BE_CHANGED)
+        self.flag(CKF_USER_PIN_TO_BE_CHANGED)
     }
 
     /// Sets value of [`CKF_USER_PIN_TO_BE_CHANGED`]
@@ -808,7 +808,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_SO_PIN_COUNT_LOW`]
     pub fn so_pin_count_low(&self) -> bool {
-        self.get_flag(CKF_SO_PIN_COUNT_LOW)
+        self.flag(CKF_SO_PIN_COUNT_LOW)
     }
 
     /// Sets value of [`CKF_SO_PIN_COUNT_LOW`]
@@ -819,7 +819,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_SO_PIN_FINAL_TRY`]
     pub fn so_pin_final_try(&self) -> bool {
-        self.get_flag(CKF_SO_PIN_FINAL_TRY)
+        self.flag(CKF_SO_PIN_FINAL_TRY)
     }
 
     /// Sets value of [`CKF_SO_PIN_FINAL_TRY`]
@@ -830,7 +830,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_SO_PIN_LOCKED`]
     pub fn so_pin_locked(&self) -> bool {
-        self.get_flag(CKF_SO_PIN_LOCKED)
+        self.flag(CKF_SO_PIN_LOCKED)
     }
 
     /// Sets value of [`CKF_SO_PIN_LOCKED`]
@@ -841,7 +841,7 @@ impl TokenFlags {
 
     /// Gets value of [`CKF_SO_PIN_TO_BE_CHANGED`]
     pub fn so_pin_to_be_changed(&self) -> bool {
-        self.get_flag(CKF_SO_PIN_TO_BE_CHANGED)
+        self.flag(CKF_SO_PIN_TO_BE_CHANGED)
     }
 
     /// Sets value of [`CKF_SO_PIN_TO_BE_CHANGED`]
@@ -996,12 +996,12 @@ impl std::fmt::Display for Version {
 
 impl Version {
     /// Returns the major version
-    pub fn get_major(&self) -> CK_BYTE {
+    pub fn major(&self) -> CK_BYTE {
         self.major
     }
 
     /// Returns the minor version
-    pub fn get_minor(&self) -> CK_BYTE {
+    pub fn minor(&self) -> CK_BYTE {
         self.minor
     }
 }
@@ -1036,28 +1036,28 @@ impl Info {
     }
 
     /// Returns the version of Cryptoki that the library is compatible with
-    pub fn get_cryptoki_version(&self) -> Version {
+    pub fn cryptoki_version(&self) -> Version {
         self.val.cryptokiVersion.into()
     }
 
     /// Returns the flags of the library (should be zero!)
-    pub fn get_flags(&self) -> CK_FLAGS {
+    pub fn flags(&self) -> CK_FLAGS {
         self.val.flags
     }
 
     /// Returns the description of the library
-    pub fn get_library_description(&self) -> String {
-        str_from_blank_padded(&self.val.libraryDescription)
+    pub fn library_description(&self) -> String {
+        string_from_blank_padded(&self.val.libraryDescription)
     }
 
     /// Returns the version of the library
-    pub fn get_library_version(&self) -> Version {
+    pub fn library_version(&self) -> Version {
         self.val.libraryVersion.into()
     }
 
     /// Returns the manufacturer of the library
-    pub fn get_manufacturer_id(&self) -> String {
-        str_from_blank_padded(&self.val.manufacturerID)
+    pub fn manufacturer_id(&self) -> String {
+        string_from_blank_padded(&self.val.manufacturerID)
     }
 }
 

--- a/cryptoki/src/types/object.rs
+++ b/cryptoki/src/types/object.rs
@@ -497,7 +497,11 @@ impl TryFrom<CK_OBJECT_CLASS> for ObjectClass {
 
     fn try_from(object_class: CK_OBJECT_CLASS) -> Result<Self> {
         match object_class {
+            CKO_DATA => Ok(ObjectClass::DATA),
+            CKO_PRIVATE_KEY => Ok(ObjectClass::PRIVATE_KEY),
+            CKO_SECRET_KEY => Ok(ObjectClass::SECRET_KEY),
             CKO_PUBLIC_KEY => Ok(ObjectClass::PUBLIC_KEY),
+            CKO_CERTIFICATE => Ok(ObjectClass::CERTIFICATE),
             other => {
                 error!("Object class {} is not supported.", other);
                 Err(Error::NotSupported)

--- a/cryptoki/src/types/session.rs
+++ b/cryptoki/src/types/session.rs
@@ -3,9 +3,13 @@
 //! Session types
 
 use crate::types::slot_token::Slot;
+use crate::types::{SessionFlags, Ulong};
 use crate::Pkcs11;
 use cryptoki_sys::*;
 use log::error;
+use std::convert::TryInto;
+use std::fmt::Formatter;
+use std::ops::Deref;
 
 /// Type that identifies a session
 ///
@@ -21,6 +25,24 @@ pub struct Session<'a> {
     slot: Slot,
     // This is not used but to prevent Session to automatically implement Send and Sync
     _guard: *mut u32,
+}
+
+impl std::fmt::Display for Session<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.handle)
+    }
+}
+
+impl std::fmt::LowerHex for Session<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:08x}", self.handle)
+    }
+}
+
+impl std::fmt::UpperHex for Session<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:08x}", self.handle)
+    }
 }
 
 // Session does not implement Sync to prevent the same Session instance to be used from multiple
@@ -81,5 +103,107 @@ impl From<UserType> for CK_USER_TYPE {
             UserType::User => CKU_USER,
             UserType::ContextSpecific => CKU_CONTEXT_SPECIFIC,
         }
+    }
+}
+
+/// Represents the state of a session
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SessionState {
+    val: CK_STATE,
+}
+
+impl SessionState {
+    /// Read-only public session
+    pub const RO_PUBLIC_SESSION: SessionState = SessionState {
+        val: CKS_RO_PUBLIC_SESSION,
+    };
+
+    /// Read-only user access
+    pub const RO_USER_FUNCTIONS: SessionState = SessionState {
+        val: CKS_RO_USER_FUNCTIONS,
+    };
+
+    /// Read/write public session
+    pub const RW_PUBLIC_SESSION: SessionState = SessionState {
+        val: CKS_RW_PUBLIC_SESSION,
+    };
+
+    /// Read/write user access
+    pub const RW_USER_FUNCTIONS: SessionState = SessionState {
+        val: CKS_RW_USER_FUNCTIONS,
+    };
+
+    /// Read/write SO access
+    pub const RW_SO_FUNCTIONS: SessionState = SessionState {
+        val: CKS_RW_SO_FUNCTIONS,
+    };
+
+    fn state_to_str(&self) -> &'static str {
+        match self.val {
+            CKS_RO_PUBLIC_SESSION => stringify!(CKS_RO_PUBLIC_SESSION),
+            CKS_RO_USER_FUNCTIONS => stringify!(CKS_RO_USER_FUNCTIONS),
+            CKS_RW_PUBLIC_SESSION => stringify!(CKS_RW_PUBLIC_SESSION),
+            CKS_RW_USER_FUNCTIONS => stringify!(CKS_RW_USER_FUNCTIONS),
+            CKS_RW_SO_FUNCTIONS => stringify!(CKS_RW_SO_FUNCTIONS),
+            _ => "Unknown state value",
+        }
+    }
+}
+
+impl Deref for SessionState {
+    type Target = CK_STATE;
+
+    fn deref(&self) -> &Self::Target {
+        &self.val
+    }
+}
+
+impl From<SessionState> for CK_STATE {
+    fn from(session_state: SessionState) -> Self {
+        *session_state
+    }
+}
+
+impl From<CK_STATE> for SessionState {
+    fn from(val: CK_STATE) -> Self {
+        Self { val }
+    }
+}
+
+impl std::fmt::Display for SessionState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.state_to_str())
+    }
+}
+
+/// Type identifying the session information
+#[derive(Copy, Clone, Debug)]
+pub struct SessionInfo {
+    val: CK_SESSION_INFO,
+}
+
+impl SessionInfo {
+    pub(crate) fn new(val: CK_SESSION_INFO) -> Self {
+        Self { val }
+    }
+
+    /// Returns an error code defined by the cryptographic device
+    pub fn get_device_error(&self) -> Ulong {
+        self.val.ulDeviceError.into()
+    }
+
+    /// Returns the flags for this session
+    pub fn get_flags(&self) -> SessionFlags {
+        self.val.flags.into()
+    }
+
+    /// Returns the state of the session
+    pub fn get_session_state(&self) -> SessionState {
+        self.val.state.into()
+    }
+
+    /// Returns the slot the session is on
+    pub fn get_slot_id(&self) -> Slot {
+        self.val.slotID.try_into().unwrap()
     }
 }

--- a/cryptoki/src/types/session.rs
+++ b/cryptoki/src/types/session.rs
@@ -138,8 +138,9 @@ impl SessionState {
         val: CKS_RW_SO_FUNCTIONS,
     };
 
-    fn state_to_str(&self) -> &'static str {
-        match self.val {
+    /// Stringifies the value of a [CK_STATE]
+    pub(crate) fn stringify(state: CK_STATE) -> &'static str {
+        match state {
             CKS_RO_PUBLIC_SESSION => stringify!(CKS_RO_PUBLIC_SESSION),
             CKS_RO_USER_FUNCTIONS => stringify!(CKS_RO_USER_FUNCTIONS),
             CKS_RW_PUBLIC_SESSION => stringify!(CKS_RW_PUBLIC_SESSION),
@@ -172,7 +173,7 @@ impl From<CK_STATE> for SessionState {
 
 impl std::fmt::Display for SessionState {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.state_to_str())
+        write!(f, "{}", SessionState::stringify(self.val))
     }
 }
 
@@ -188,22 +189,22 @@ impl SessionInfo {
     }
 
     /// Returns an error code defined by the cryptographic device
-    pub fn get_device_error(&self) -> Ulong {
+    pub fn device_error(&self) -> Ulong {
         self.val.ulDeviceError.into()
     }
 
     /// Returns the flags for this session
-    pub fn get_flags(&self) -> SessionFlags {
+    pub fn flags(&self) -> SessionFlags {
         self.val.flags.into()
     }
 
     /// Returns the state of the session
-    pub fn get_session_state(&self) -> SessionState {
+    pub fn session_state(&self) -> SessionState {
         self.val.state.into()
     }
 
     /// Returns the slot the session is on
-    pub fn get_slot_id(&self) -> Slot {
+    pub fn slot_id(&self) -> Slot {
         self.val.slotID.try_into().unwrap()
     }
 }

--- a/cryptoki/src/types/session.rs
+++ b/cryptoki/src/types/session.rs
@@ -41,7 +41,7 @@ impl std::fmt::LowerHex for Session<'_> {
 
 impl std::fmt::UpperHex for Session<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:08x}", self.handle)
+        write!(f, "{:08X}", self.handle)
     }
 }
 

--- a/cryptoki/src/types/session.rs
+++ b/cryptoki/src/types/session.rs
@@ -205,6 +205,8 @@ impl SessionInfo {
 
     /// Returns the slot the session is on
     pub fn slot_id(&self) -> Slot {
+        // The unwrap should not fail as `slotID` is a `CK_SLOT_ID ` which is the same type as
+        // `slot_id` within the `Slot` structure
         self.val.slotID.try_into().unwrap()
     }
 }

--- a/cryptoki/src/types/slot_token.rs
+++ b/cryptoki/src/types/slot_token.rs
@@ -6,16 +6,33 @@
 
 //! Slot and token types
 
-use crate::types::Flags;
-use crate::{Error, Result};
-use cryptoki_sys::{CK_SLOT_ID, CK_TOKEN_INFO};
+use crate::types::{SlotFlags, TokenFlags, Ulong, Version};
+use crate::{str_from_blank_padded, Error, Result};
+use cryptoki_sys::{CK_SLOT_ID, CK_SLOT_INFO, CK_TOKEN_INFO};
 use std::convert::{TryFrom, TryInto};
+use std::fmt::Formatter;
 use std::ops::Deref;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Type identifying a slot
 pub struct Slot {
     slot_id: CK_SLOT_ID,
+}
+
+impl std::fmt::LowerHex for Slot {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let val = self.slot_id;
+
+        std::fmt::LowerHex::fmt(&val, f)
+    }
+}
+
+impl std::fmt::UpperHex for Slot {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let val = self.slot_id;
+
+        std::fmt::UpperHex::fmt(&val, f)
+    }
 }
 
 impl Slot {
@@ -39,9 +56,76 @@ impl TryFrom<u64> for Slot {
     }
 }
 
+impl TryFrom<u32> for Slot {
+    type Error = Error;
+
+    fn try_from(slot_id: u32) -> Result<Self> {
+        Ok(Self {
+            slot_id: slot_id.try_into()?,
+        })
+    }
+}
+
 impl From<Slot> for CK_SLOT_ID {
     fn from(slot: Slot) -> Self {
         slot.slot_id
+    }
+}
+
+impl std::fmt::Display for Slot {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.slot_id)
+    }
+}
+
+/// Contains information about the slot
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SlotInfo {
+    val: CK_SLOT_INFO,
+}
+
+impl SlotInfo {
+    pub(crate) fn new(val: CK_SLOT_INFO) -> Self {
+        Self { val }
+    }
+
+    /// Returns the firmware version
+    pub fn get_firmware_version(&self) -> Version {
+        self.val.firmwareVersion.into()
+    }
+
+    /// Returns the flags of the slot
+    pub fn get_flags(&self) -> SlotFlags {
+        self.val.flags.into()
+    }
+
+    /// Returns the hardware version
+    pub fn get_hardware_version(&self) -> Version {
+        self.val.hardwareVersion.into()
+    }
+
+    /// Returns the manufacturer ID
+    pub fn get_manufacturer_id(&self) -> String {
+        str_from_blank_padded(&self.val.manufacturerID)
+    }
+
+    /// Returns the slot description
+    pub fn get_slot_description(&self) -> String {
+        str_from_blank_padded(&self.val.slotDescription)
+    }
+}
+
+impl Deref for SlotInfo {
+    type Target = CK_SLOT_INFO;
+
+    fn deref(&self) -> &Self::Target {
+        &self.val
+    }
+}
+
+impl From<SlotInfo> for CK_SLOT_INFO {
+    fn from(token_info: SlotInfo) -> Self {
+        *token_info
     }
 }
 
@@ -56,22 +140,97 @@ impl TokenInfo {
         Self { val }
     }
 
+    /// Returns the firmware version
+    pub fn get_firmware_version(&self) -> Version {
+        self.val.firmwareVersion.into()
+    }
+
+    /// Returns the free private memory
+    pub fn get_free_private_memory(&self) -> Ulong {
+        self.val.ulFreePrivateMemory.into()
+    }
+
+    /// Returns the free public memory
+    pub fn get_free_public_memory(&self) -> Ulong {
+        self.val.ulFreePublicMemory.into()
+    }
+
+    /// Returns the hardware version
+    pub fn get_hardware_version(&self) -> Version {
+        self.val.hardwareVersion.into()
+    }
+
+    /// Returns the label of the token
+    pub fn get_label(&self) -> String {
+        str_from_blank_padded(&self.val.label)
+    }
+
     /// Returns the ID of the device manufacturer
     pub fn get_manufacturer_id(&self) -> String {
-        String::from_utf8_lossy(&self.val.manufacturerID)
-            .trim_end()
-            .to_string()
+        str_from_blank_padded(&self.val.manufacturerID)
+    }
+
+    /// Returns the max PIN length
+    pub fn get_max_pin_length(&self) -> Ulong {
+        self.val.ulMaxPinLen.into()
+    }
+
+    /// Returns the max session count
+    pub fn get_max_session_count(&self) -> Ulong {
+        self.val.ulMaxSessionCount.into()
+    }
+
+    /// Returns the max r/w session count
+    pub fn get_max_rw_session_count(&self) -> Ulong {
+        self.val.ulMaxRwSessionCount.into()
+    }
+
+    /// Returns the min PIN length
+    pub fn get_min_pin_length(&self) -> Ulong {
+        self.val.ulMinPinLen.into()
+    }
+
+    /// Returns the model of the token
+    pub fn get_model(&self) -> String {
+        str_from_blank_padded(&self.val.model)
+    }
+
+    /// Returns the r/w session count
+    pub fn get_rw_session_count(&self) -> Ulong {
+        self.val.ulRwSessionCount.into()
     }
 
     /// Returns the character-string serial number of the device
     pub fn get_serial_number(&self) -> String {
-        String::from_utf8_lossy(&self.val.serialNumber)
+        str_from_blank_padded(&self.val.serialNumber)
+    }
+
+    /// Returns current session count
+    pub fn get_session_count(&self) -> Ulong {
+        self.val.ulSessionCount.into()
+    }
+
+    /// Returns the total private memory
+    pub fn get_total_private_memory(&self) -> Ulong {
+        self.val.ulTotalPrivateMemory.into()
+    }
+
+    /// Returns the total public memory
+    pub fn get_total_public_memory(&self) -> Ulong {
+        self.val.ulTotalPublicMemory.into()
+    }
+
+    /// Returns the UTC Time of the token
+    pub fn get_utc_time(&self) -> String {
+        // UTC time is not blank padded as it has the format YYYYMMDDhhmmssxx where
+        // x is the '0' character
+        String::from_utf8_lossy(&self.val.utcTime)
             .trim_end()
             .to_string()
     }
 
     /// Returns the Token's flags
-    pub fn get_flags(&self) -> Flags {
+    pub fn get_flags(&self) -> TokenFlags {
         self.val.flags.into()
     }
 }

--- a/cryptoki/src/types/slot_token.rs
+++ b/cryptoki/src/types/slot_token.rs
@@ -7,7 +7,7 @@
 //! Slot and token types
 
 use crate::types::{SlotFlags, TokenFlags, Ulong, Version};
-use crate::{str_from_blank_padded, Error, Result};
+use crate::{string_from_blank_padded, Error, Result};
 use cryptoki_sys::{CK_SLOT_ID, CK_SLOT_INFO, CK_TOKEN_INFO};
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Formatter;
@@ -90,28 +90,28 @@ impl SlotInfo {
     }
 
     /// Returns the firmware version
-    pub fn get_firmware_version(&self) -> Version {
+    pub fn firmware_version(&self) -> Version {
         self.val.firmwareVersion.into()
     }
 
     /// Returns the flags of the slot
-    pub fn get_flags(&self) -> SlotFlags {
+    pub fn flags(&self) -> SlotFlags {
         self.val.flags.into()
     }
 
     /// Returns the hardware version
-    pub fn get_hardware_version(&self) -> Version {
+    pub fn hardware_version(&self) -> Version {
         self.val.hardwareVersion.into()
     }
 
     /// Returns the manufacturer ID
-    pub fn get_manufacturer_id(&self) -> String {
-        str_from_blank_padded(&self.val.manufacturerID)
+    pub fn manufacturer_id(&self) -> String {
+        string_from_blank_padded(&self.val.manufacturerID)
     }
 
     /// Returns the slot description
-    pub fn get_slot_description(&self) -> String {
-        str_from_blank_padded(&self.val.slotDescription)
+    pub fn slot_description(&self) -> String {
+        string_from_blank_padded(&self.val.slotDescription)
     }
 }
 
@@ -141,87 +141,87 @@ impl TokenInfo {
     }
 
     /// Returns the firmware version
-    pub fn get_firmware_version(&self) -> Version {
+    pub fn firmware_version(&self) -> Version {
         self.val.firmwareVersion.into()
     }
 
     /// Returns the free private memory
-    pub fn get_free_private_memory(&self) -> Ulong {
+    pub fn free_private_memory(&self) -> Ulong {
         self.val.ulFreePrivateMemory.into()
     }
 
     /// Returns the free public memory
-    pub fn get_free_public_memory(&self) -> Ulong {
+    pub fn free_public_memory(&self) -> Ulong {
         self.val.ulFreePublicMemory.into()
     }
 
     /// Returns the hardware version
-    pub fn get_hardware_version(&self) -> Version {
+    pub fn hardware_version(&self) -> Version {
         self.val.hardwareVersion.into()
     }
 
     /// Returns the label of the token
-    pub fn get_label(&self) -> String {
-        str_from_blank_padded(&self.val.label)
+    pub fn label(&self) -> String {
+        string_from_blank_padded(&self.val.label)
     }
 
     /// Returns the ID of the device manufacturer
-    pub fn get_manufacturer_id(&self) -> String {
-        str_from_blank_padded(&self.val.manufacturerID)
+    pub fn manufacturer_id(&self) -> String {
+        string_from_blank_padded(&self.val.manufacturerID)
     }
 
     /// Returns the max PIN length
-    pub fn get_max_pin_length(&self) -> Ulong {
+    pub fn max_pin_length(&self) -> Ulong {
         self.val.ulMaxPinLen.into()
     }
 
     /// Returns the max session count
-    pub fn get_max_session_count(&self) -> Ulong {
+    pub fn max_session_count(&self) -> Ulong {
         self.val.ulMaxSessionCount.into()
     }
 
     /// Returns the max r/w session count
-    pub fn get_max_rw_session_count(&self) -> Ulong {
+    pub fn max_rw_session_count(&self) -> Ulong {
         self.val.ulMaxRwSessionCount.into()
     }
 
     /// Returns the min PIN length
-    pub fn get_min_pin_length(&self) -> Ulong {
+    pub fn min_pin_length(&self) -> Ulong {
         self.val.ulMinPinLen.into()
     }
 
     /// Returns the model of the token
-    pub fn get_model(&self) -> String {
-        str_from_blank_padded(&self.val.model)
+    pub fn model(&self) -> String {
+        string_from_blank_padded(&self.val.model)
     }
 
     /// Returns the r/w session count
-    pub fn get_rw_session_count(&self) -> Ulong {
+    pub fn rw_session_count(&self) -> Ulong {
         self.val.ulRwSessionCount.into()
     }
 
     /// Returns the character-string serial number of the device
-    pub fn get_serial_number(&self) -> String {
-        str_from_blank_padded(&self.val.serialNumber)
+    pub fn serial_number(&self) -> String {
+        string_from_blank_padded(&self.val.serialNumber)
     }
 
     /// Returns current session count
-    pub fn get_session_count(&self) -> Ulong {
+    pub fn session_count(&self) -> Ulong {
         self.val.ulSessionCount.into()
     }
 
     /// Returns the total private memory
-    pub fn get_total_private_memory(&self) -> Ulong {
+    pub fn total_private_memory(&self) -> Ulong {
         self.val.ulTotalPrivateMemory.into()
     }
 
     /// Returns the total public memory
-    pub fn get_total_public_memory(&self) -> Ulong {
+    pub fn total_public_memory(&self) -> Ulong {
         self.val.ulTotalPublicMemory.into()
     }
 
     /// Returns the UTC Time of the token
-    pub fn get_utc_time(&self) -> String {
+    pub fn utc_time(&self) -> String {
         // UTC time is not blank padded as it has the format YYYYMMDDhhmmssxx where
         // x is the '0' character
         String::from_utf8_lossy(&self.val.utcTime)
@@ -230,7 +230,7 @@ impl TokenInfo {
     }
 
     /// Returns the Token's flags
-    pub fn get_flags(&self) -> TokenFlags {
+    pub fn flags(&self) -> TokenFlags {
         self.val.flags.into()
     }
 }

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -290,7 +290,7 @@ fn import_export() {
 fn get_token_info() {
     let (pkcs11, slot) = init_pins();
     let info = pkcs11.get_token_info(slot).unwrap();
-    assert_eq!("SoftHSM project", info.get_manufacturer_id());
+    assert_eq!("SoftHSM project", info.manufacturer_id());
 }
 
 #[test]
@@ -331,9 +331,9 @@ fn get_info_test() -> Result<(), Box<dyn Error>> {
     let (pkcs11, _) = init_pins();
     let info = pkcs11.get_library_info()?;
 
-    assert_eq!(info.get_cryptoki_version().get_major(), 2);
-    assert_eq!(info.get_cryptoki_version().get_minor(), 40);
-    assert_eq!(info.get_manufacturer_id(), String::from("SoftHSM"));
+    assert_eq!(info.cryptoki_version().major(), 2);
+    assert_eq!(info.cryptoki_version().minor(), 40);
+    assert_eq!(info.manufacturer_id(), String::from("SoftHSM"));
     Ok(())
 }
 
@@ -342,13 +342,10 @@ fn get_info_test() -> Result<(), Box<dyn Error>> {
 fn get_slot_info_test() -> Result<(), Box<dyn Error>> {
     let (pkcs11, slot) = init_pins();
     let slot_info = pkcs11.get_slot_info(slot)?;
-    assert!(slot_info.get_flags().token_present());
-    assert!(!slot_info.get_flags().hardware_slot());
-    assert!(!slot_info.get_flags().removable_device());
-    assert_eq!(
-        slot_info.get_manufacturer_id(),
-        String::from("SoftHSM project")
-    );
+    assert!(slot_info.flags().token_present());
+    assert!(!slot_info.flags().hardware_slot());
+    assert!(!slot_info.flags().removable_device());
+    assert_eq!(slot_info.manufacturer_id(), String::from("SoftHSM project"));
     Ok(())
 }
 
@@ -370,19 +367,19 @@ fn get_session_info_test() -> Result<(), Box<dyn Error>> {
     {
         let session = pkcs11.open_session_no_callback(slot, flags)?;
         let session_info = session.get_session_info()?;
-        assert_eq!(session_info.get_flags(), flags);
-        assert_eq!(session_info.get_slot_id(), slot);
+        assert_eq!(session_info.flags(), flags);
+        assert_eq!(session_info.slot_id(), slot);
         assert_eq!(
-            session_info.get_session_state(),
+            session_info.session_state(),
             SessionState::RO_PUBLIC_SESSION
         );
 
         session.login(UserType::User)?;
         let session_info = session.get_session_info()?;
-        assert_eq!(session_info.get_flags(), flags);
-        assert_eq!(session_info.get_slot_id(), slot);
+        assert_eq!(session_info.flags(), flags);
+        assert_eq!(session_info.slot_id(), slot);
         assert_eq!(
-            session_info.get_session_state(),
+            session_info.session_state(),
             SessionState::RO_USER_FUNCTIONS
         );
         session.logout()?;
@@ -397,30 +394,27 @@ fn get_session_info_test() -> Result<(), Box<dyn Error>> {
 
     let session = pkcs11.open_session_no_callback(slot, flags)?;
     let session_info = session.get_session_info()?;
-    assert_eq!(session_info.get_flags(), flags);
-    assert_eq!(session_info.get_slot_id(), slot);
+    assert_eq!(session_info.flags(), flags);
+    assert_eq!(session_info.slot_id(), slot);
     assert_eq!(
-        session_info.get_session_state(),
+        session_info.session_state(),
         SessionState::RW_PUBLIC_SESSION
     );
 
     session.login(UserType::User)?;
     let session_info = session.get_session_info()?;
-    assert_eq!(session_info.get_flags(), flags);
-    assert_eq!(session_info.get_slot_id(), slot);
+    assert_eq!(session_info.flags(), flags);
+    assert_eq!(session_info.slot_id(), slot);
     assert_eq!(
-        session_info.get_session_state(),
+        session_info.session_state(),
         SessionState::RW_USER_FUNCTIONS
     );
     session.logout()?;
     session.login(UserType::So)?;
     let session_info = session.get_session_info()?;
-    assert_eq!(session_info.get_flags(), flags);
-    assert_eq!(session_info.get_slot_id(), slot);
-    assert_eq!(
-        session_info.get_session_state(),
-        SessionState::RW_SO_FUNCTIONS
-    );
+    assert_eq!(session_info.flags(), flags);
+    assert_eq!(session_info.slot_id(), slot);
+    assert_eq!(session_info.session_state(), SessionState::RW_SO_FUNCTIONS);
 
     Ok(())
 }

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -3,11 +3,13 @@
 mod common;
 
 use common::init_pins;
+use cryptoki::types::function::RvError;
 use cryptoki::types::mechanism::Mechanism;
 use cryptoki::types::object::{Attribute, AttributeInfo, AttributeType, KeyType, ObjectClass};
-use cryptoki::types::session::UserType;
-use cryptoki::types::Flags;
+use cryptoki::types::session::{SessionState, UserType};
+use cryptoki::types::SessionFlags;
 use serial_test::serial;
+use std::error::Error;
 use std::sync::Arc;
 use std::thread;
 
@@ -17,7 +19,7 @@ fn sign_verify() {
     let (pkcs11, slot) = init_pins();
 
     // set flags
-    let mut flags = Flags::new();
+    let mut flags = SessionFlags::new();
     let _ = flags.set_rw_session(true).set_serial_session(true);
 
     // open a session
@@ -70,7 +72,7 @@ fn encrypt_decrypt() {
     let (pkcs11, slot) = init_pins();
 
     // set flags
-    let mut flags = Flags::new();
+    let mut flags = SessionFlags::new();
     let _ = flags.set_rw_session(true).set_serial_session(true);
 
     // open a session
@@ -130,7 +132,7 @@ fn derive_key() {
     let (pkcs11, slot) = init_pins();
 
     // set flags
-    let mut flags = Flags::new();
+    let mut flags = SessionFlags::new();
     let _ = flags.set_rw_session(true).set_serial_session(true);
 
     // open a session
@@ -228,7 +230,7 @@ fn import_export() {
     let (pkcs11, slot) = init_pins();
 
     // set flags
-    let mut flags = Flags::new();
+    let mut flags = SessionFlags::new();
     let _ = flags.set_rw_session(true).set_serial_session(true);
 
     // open a session
@@ -299,7 +301,7 @@ fn login_feast() {
     let (pkcs11, slot) = init_pins();
 
     // set flags
-    let mut flags = Flags::new();
+    let mut flags = SessionFlags::new();
     let _ = flags.set_rw_session(true).set_serial_session(true);
 
     let pkcs11 = Arc::from(pkcs11);
@@ -321,4 +323,104 @@ fn login_feast() {
     for thread in threads {
         thread.join().unwrap();
     }
+}
+
+#[test]
+#[serial]
+fn get_info_test() -> Result<(), Box<dyn Error>> {
+    let (pkcs11, _) = init_pins();
+    let info = pkcs11.get_library_info()?;
+
+    assert_eq!(info.get_cryptoki_version().get_major(), 2);
+    assert_eq!(info.get_cryptoki_version().get_minor(), 40);
+    assert_eq!(info.get_manufacturer_id(), String::from("SoftHSM"));
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn get_slot_info_test() -> Result<(), Box<dyn Error>> {
+    let (pkcs11, slot) = init_pins();
+    let slot_info = pkcs11.get_slot_info(slot)?;
+    assert!(slot_info.get_flags().token_present());
+    assert!(!slot_info.get_flags().hardware_slot());
+    assert!(!slot_info.get_flags().removable_device());
+    assert_eq!(
+        slot_info.get_manufacturer_id(),
+        String::from("SoftHSM project")
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn get_session_info_test() -> Result<(), Box<dyn Error>> {
+    let (pkcs11, slot) = init_pins();
+
+    let mut flags = SessionFlags::new();
+
+    // Check that OpenSession errors when CKF_SERIAL_SESSION is not set
+    if let Err(cryptoki::Error::Pkcs11(rv_error)) = pkcs11.open_session_no_callback(slot, flags) {
+        assert_eq!(rv_error, RvError::SessionParallelNotSupported);
+    } else {
+        panic!("Should error when CKF_SERIAL_SESSION is not set");
+    }
+
+    let _ = flags.set_serial_session(true);
+    {
+        let session = pkcs11.open_session_no_callback(slot, flags)?;
+        let session_info = session.get_session_info()?;
+        assert_eq!(session_info.get_flags(), flags);
+        assert_eq!(session_info.get_slot_id(), slot);
+        assert_eq!(
+            session_info.get_session_state(),
+            SessionState::RO_PUBLIC_SESSION
+        );
+
+        session.login(UserType::User)?;
+        let session_info = session.get_session_info()?;
+        assert_eq!(session_info.get_flags(), flags);
+        assert_eq!(session_info.get_slot_id(), slot);
+        assert_eq!(
+            session_info.get_session_state(),
+            SessionState::RO_USER_FUNCTIONS
+        );
+        session.logout()?;
+        if let Err(cryptoki::Error::Pkcs11(rv_error)) = session.login(UserType::So) {
+            assert_eq!(rv_error, RvError::SessionReadOnlyExists)
+        } else {
+            panic!("Should error when attempting to log in as CKU_SO on a read-only session");
+        }
+    }
+
+    let _ = flags.set_rw_session(true);
+
+    let session = pkcs11.open_session_no_callback(slot, flags)?;
+    let session_info = session.get_session_info()?;
+    assert_eq!(session_info.get_flags(), flags);
+    assert_eq!(session_info.get_slot_id(), slot);
+    assert_eq!(
+        session_info.get_session_state(),
+        SessionState::RW_PUBLIC_SESSION
+    );
+
+    session.login(UserType::User)?;
+    let session_info = session.get_session_info()?;
+    assert_eq!(session_info.get_flags(), flags);
+    assert_eq!(session_info.get_slot_id(), slot);
+    assert_eq!(
+        session_info.get_session_state(),
+        SessionState::RW_USER_FUNCTIONS
+    );
+    session.logout()?;
+    session.login(UserType::So)?;
+    let session_info = session.get_session_info()?;
+    assert_eq!(session_info.get_flags(), flags);
+    assert_eq!(session_info.get_slot_id(), slot);
+    assert_eq!(
+        session_info.get_session_state(),
+        SessionState::RW_SO_FUNCTIONS
+    );
+
+    Ok(())
 }

--- a/cryptoki/tests/common.rs
+++ b/cryptoki/tests/common.rs
@@ -3,7 +3,7 @@
 use cryptoki::types::locking::CInitializeArgs;
 use cryptoki::types::session::UserType;
 use cryptoki::types::slot_token::Slot;
-use cryptoki::types::Flags;
+use cryptoki::types::SessionFlags;
 use cryptoki::Pkcs11;
 use std::env;
 
@@ -20,11 +20,11 @@ pub fn init_pins() -> (Pkcs11, Slot) {
     // find a slot, get the first one
     let slot = pkcs11.get_slots_with_token().unwrap().remove(0);
 
-    pkcs11.init_token(slot, "1234").unwrap();
+    pkcs11.init_token(slot, "1234", "Test Token").unwrap();
     pkcs11.set_pin(slot, "1234").unwrap();
 
     // set flags
-    let mut flags = Flags::new();
+    let mut flags = SessionFlags::new();
     let _ = flags.set_rw_session(true).set_serial_session(true);
 
     {


### PR DESCRIPTION
…en rust-cryptoki and PKCS#11 v2.40

- Removed `Flags` and replaced with specific flag structures (`SessionFlags`, `SlotFlags`, `TokenFlags`, `InitialzeFlags` and `MechanismFlags`)
- Added support for `C_GetInfo` using `Info` as the structure and `get_library_info` as the function
- Added support for `C_GetSlotInfo` using `SlotInfo` as the structure and `get_slot_info` as the function
- Added support for `C_GetSessionInfo` using `SessionInfo` as the structure and `get_session_info` as the function
- Expanded `TokenInfo` to return all information from `CK_TOKEN_INFO` structure
- A number of stringify like functions
- Added tests for added functionality