### PR TITLE
Added functions to utilize the "Random" PKCS#11 functions

### DIFF
--- a/cryptoki/src/functions/mod.rs
+++ b/cryptoki/src/functions/mod.rs
@@ -7,6 +7,7 @@ pub mod encryption;
 pub mod general_purpose;
 pub mod key_management;
 pub mod object_management;
+pub mod random;
 pub mod session_management;
 pub mod signing_macing;
 pub mod slot_token_management;

--- a/cryptoki/src/functions/random.rs
+++ b/cryptoki/src/functions/random.rs
@@ -10,6 +10,11 @@ use std::convert::TryInto;
 
 impl<'a> Session<'a> {
     /// Generates a random number and sticks it in a slice
+    ///
+    /// # Arguments
+    ///
+    /// * `random_slice` - The slice to stick the random data into.  The length of the slice represents
+    /// the number of bytes to obtain from the RBG
     pub fn generate_random_slice(&self, random_data: &mut [u8]) -> Result<()> {
         unsafe {
             Rv::from(get_pkcs11!(self.client(), C_GenerateRandom)(
@@ -22,7 +27,8 @@ impl<'a> Session<'a> {
         Ok(())
     }
 
-    /// Generates random data and returns it as a Vec<u8>
+    /// Generates random data and returns it as a Vec<u8>.  The length of the returned Vector will
+    /// be the amount of random requested, which is `random_len`.
     pub fn generate_random_vec(&self, random_len: u32) -> Result<Vec<u8>> {
         let mut result: Vec<u8> = vec![0; random_len as usize];
         unsafe {

--- a/cryptoki/src/functions/random.rs
+++ b/cryptoki/src/functions/random.rs
@@ -1,0 +1,51 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! Functions used to generate random numbers
+
+use crate::get_pkcs11;
+use crate::types::function::Rv;
+use crate::types::session::Session;
+use crate::Result;
+use std::convert::TryInto;
+
+impl<'a> Session<'a> {
+    /// Generates a random number and sticks it in a slice
+    pub fn generate_random_slice(&self, random_data: &mut [u8]) -> Result<()> {
+        unsafe {
+            Rv::from(get_pkcs11!(self.client(), C_GenerateRandom)(
+                self.handle(),
+                random_data.as_ptr() as *mut u8,
+                random_data.len().try_into()?,
+            ))
+            .into_result()?;
+        }
+        Ok(())
+    }
+
+    /// Generates random data and returns it as a Vec<u8>
+    pub fn generate_random_vec(&self, random_len: u32) -> Result<Vec<u8>> {
+        let mut result: Vec<u8> = vec![0; random_len as usize];
+        unsafe {
+            Rv::from(get_pkcs11!(self.client(), C_GenerateRandom)(
+                self.handle(),
+                result.as_mut_ptr() as *mut u8,
+                random_len.try_into()?,
+            ))
+            .into_result()?;
+        }
+        Ok(result)
+    }
+
+    /// Seeds the RNG
+    pub fn seed_random(&self, seed: &[u8]) -> Result<()> {
+        unsafe {
+            Rv::from(get_pkcs11!(self.client(), C_SeedRandom)(
+                self.handle(),
+                seed.as_ptr() as *mut u8,
+                seed.len().try_into()?,
+            ))
+            .into_result()?;
+        }
+        Ok(())
+    }
+}

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -418,3 +418,29 @@ fn get_session_info_test() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+#[serial]
+fn generate_random_test() -> Result<(), Box<dyn Error>> {
+    let (pkcs11, slot) = init_pins();
+
+    let mut flags = SessionFlags::new();
+
+    let _ = flags.set_serial_session(true);
+    let session = pkcs11.open_session_no_callback(slot, flags)?;
+
+    let poor_seed: [u8; 32] = [0; 32];
+    session.seed_random(&poor_seed)?;
+
+    let mut random_data: [u8; 32] = [0; 32];
+    session.generate_random_slice(&mut random_data)?;
+
+    // This of course assumes the RBG in the the SoftHSM is not terrible
+    assert!(!random_data.iter().all(|&x| x == 0));
+
+    let random_vec = session.generate_random_vec(32)?;
+    assert_eq!(random_vec.len(), 32);
+
+    assert!(!random_vec.iter().all(|&x| x == 0));
+    Ok(())
+}


### PR DESCRIPTION
- Added `generate_random_slice` which will put random data into a provided slice
- Added `generate_random_vec` which will return random data in a `Vec<u8>`
- Added `seed_random` which will seed the RNG on the token

Signed-off-by: Michael J Boquard <michael.j.boquard@gmail.com>