### PR TITLE
Fixes to address #50

### DIFF
--- a/cryptoki/src/functions/object_management.rs
+++ b/cryptoki/src/functions/object_management.rs
@@ -134,9 +134,8 @@ impl<'a> Session<'a> {
     /// let mut flags = SessionFlags::new();
     /// let _ = flags.set_rw_session(true).set_serial_session(true);
     ///
-    /// pkcs11.set_pin(slot, "1234").unwrap();
     /// let session = pkcs11.open_session_no_callback(slot, flags).unwrap();
-    /// session.login(UserType::User);
+    /// session.login(UserType::User, "fedcba");
     ///
     /// let empty_attrib= vec![];
     /// if let Some(object) = session.find_objects(&empty_attrib).unwrap().get(0) {

--- a/cryptoki/src/functions/object_management.rs
+++ b/cryptoki/src/functions/object_management.rs
@@ -135,7 +135,7 @@ impl<'a> Session<'a> {
     /// let _ = flags.set_rw_session(true).set_serial_session(true);
     ///
     /// let session = pkcs11.open_session_no_callback(slot, flags).unwrap();
-    /// session.login(UserType::User, "fedcba");
+    /// session.login(UserType::User, Some("fedcba"));
     ///
     /// let empty_attrib= vec![];
     /// if let Some(object) = session.find_objects(&empty_attrib).unwrap().get(0) {

--- a/cryptoki/src/functions/session_management.rs
+++ b/cryptoki/src/functions/session_management.rs
@@ -42,20 +42,26 @@ impl<'a> Session<'a> {
         unsafe { Rv::from(get_pkcs11!(self.client(), C_CloseSession)(self.handle())).into_result() }
     }
 
-    /// Log a session in
-    ///
-    /// Do not fail if the user is already logged in. It happens if another session on the same slot
-    /// has already called the log in operation. Record the login call and only log out when there
-    /// aren't anymore sessions requiring log in state.
-    pub fn login(&self, user_type: UserType) -> Result<()> {
-        self.client().login(self, user_type)
+    /// Log a session in.
+    pub fn login(&self, user_type: UserType, pin: &str) -> Result<()> {
+        let pin_ptr = match pin.len() {
+            0 => std::ptr::null_mut(),
+            _ => pin.as_ptr() as *mut u8,
+        };
+        unsafe {
+            Rv::from(get_pkcs11!(self.client(), C_Login)(
+                self.handle(),
+                user_type.into(),
+                pin_ptr,
+                pin.len().try_into()?,
+            ))
+            .into_result()
+        }
     }
 
     /// Log a session out
-    ///
-    /// Will also be called on drop.
     pub fn logout(&self) -> Result<()> {
-        self.client().logout(self)
+        unsafe { Rv::from(get_pkcs11!(self.client(), C_Logout)(self.handle())).into_result() }
     }
 
     /// Returns the information about a session

--- a/cryptoki/src/types/session.rs
+++ b/cryptoki/src/types/session.rs
@@ -66,19 +66,10 @@ impl<'a> Session<'a> {
     pub(crate) fn client(&self) -> &Pkcs11 {
         self.client
     }
-
-    pub(crate) fn slot(&self) -> Slot {
-        self.slot
-    }
 }
 
 impl Drop for Session<'_> {
     fn drop(&mut self) {
-        // logout is ignored if the session is not logged in
-        if let Err(e) = self.logout() {
-            error!("Failed to logout session: {}", e);
-        }
-
         if let Err(e) = self.close_private() {
             error!("Failed to close session: {}", e);
         }

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 mod common;
 
+use crate::common::{SO_PIN, USER_PIN};
 use common::init_pins;
 use cryptoki::types::function::RvError;
 use cryptoki::types::mechanism::Mechanism;
@@ -28,9 +29,7 @@ type Result<T> = std::result::Result<T, ErrorWithStacktrace>;
 #[test]
 #[serial]
 fn sign_verify() -> Result<()> {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -40,7 +39,7 @@ fn sign_verify() -> Result<()> {
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
     // log in the session
-    session.login(UserType::User, user_pin)?;
+    session.login(UserType::User, Some(USER_PIN))?;
 
     // get mechanism
     let mechanism = Mechanism::RsaPkcsKeyPairGen;
@@ -82,9 +81,7 @@ fn sign_verify() -> Result<()> {
 #[test]
 #[serial]
 fn encrypt_decrypt() -> Result<()> {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -94,7 +91,7 @@ fn encrypt_decrypt() -> Result<()> {
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
     // log in the session
-    session.login(UserType::User, user_pin)?;
+    session.login(UserType::User, Some(USER_PIN))?;
 
     // get mechanism
     let mechanism = Mechanism::RsaPkcsKeyPairGen;
@@ -143,9 +140,7 @@ fn encrypt_decrypt() -> Result<()> {
 #[test]
 #[serial]
 fn derive_key() -> Result<()> {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -155,7 +150,7 @@ fn derive_key() -> Result<()> {
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
     // log in the session
-    session.login(UserType::User, user_pin)?;
+    session.login(UserType::User, Some(USER_PIN))?;
 
     // get mechanism
     let mechanism = Mechanism::EccKeyPairGen;
@@ -240,9 +235,7 @@ fn derive_key() -> Result<()> {
 #[test]
 #[serial]
 fn import_export() -> Result<()> {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -252,7 +245,7 @@ fn import_export() -> Result<()> {
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
     // log in the session
-    session.login(UserType::User, user_pin)?;
+    session.login(UserType::User, Some(USER_PIN))?;
 
     let public_exponent: Vec<u8> = vec![0x01, 0x00, 0x01];
     let modulus = vec![0xFF; 1024];
@@ -303,9 +296,7 @@ fn import_export() -> Result<()> {
 #[test]
 #[serial]
 fn get_token_info() -> Result<()> {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
     let info = pkcs11.get_token_info(slot)?;
     assert_eq!("SoftHSM project", info.manufacturer_id());
 
@@ -315,9 +306,7 @@ fn get_token_info() -> Result<()> {
 #[test]
 #[serial]
 fn wrap_and_unwrap_key() {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
     // set flags
     let mut flags = SessionFlags::new();
     let _ = flags.set_rw_session(true).set_serial_session(true);
@@ -326,7 +315,7 @@ fn wrap_and_unwrap_key() {
     let session = pkcs11.open_session_no_callback(slot, flags).unwrap();
 
     // log in the session
-    session.login(UserType::User, user_pin).unwrap();
+    session.login(UserType::User, Some(USER_PIN)).unwrap();
 
     let key_to_be_wrapped_template = vec![
         Attribute::Token(true.into()),
@@ -406,9 +395,7 @@ fn wrap_and_unwrap_key() {
 fn login_feast() {
     const SESSIONS: usize = 100;
 
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -421,15 +408,15 @@ fn login_feast() {
         let pkcs11 = pkcs11.clone();
         threads.push(thread::spawn(move || {
             let session = pkcs11.open_session_no_callback(slot, flags).unwrap();
-            match session.login(UserType::User, user_pin) {
+            match session.login(UserType::User, Some(USER_PIN)) {
                 Ok(_) | Err(Error::Pkcs11(RvError::UserAlreadyLoggedIn)) => {}
                 Err(e) => panic!("Bad error response: {}", e),
             }
-            match session.login(UserType::User, user_pin) {
+            match session.login(UserType::User, Some(USER_PIN)) {
                 Ok(_) | Err(Error::Pkcs11(RvError::UserAlreadyLoggedIn)) => {}
                 Err(e) => panic!("Bad error response: {}", e),
             }
-            match session.login(UserType::User, user_pin) {
+            match session.login(UserType::User, Some(USER_PIN)) {
                 Ok(_) | Err(Error::Pkcs11(RvError::UserAlreadyLoggedIn)) => {}
                 Err(e) => panic!("Bad error response: {}", e),
             }
@@ -456,9 +443,7 @@ fn login_feast() {
 #[test]
 #[serial]
 fn get_info_test() -> Result<()> {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, _) = init_pins(so_pin, user_pin);
+    let (pkcs11, _) = init_pins();
     let info = pkcs11.get_library_info()?;
 
     assert_eq!(info.cryptoki_version().major(), 2);
@@ -470,9 +455,7 @@ fn get_info_test() -> Result<()> {
 #[test]
 #[serial]
 fn get_slot_info_test() -> Result<()> {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
     let slot_info = pkcs11.get_slot_info(slot)?;
     assert!(slot_info.flags().token_present());
     assert!(!slot_info.flags().hardware_slot());
@@ -484,9 +467,7 @@ fn get_slot_info_test() -> Result<()> {
 #[test]
 #[serial]
 fn get_session_info_test() -> Result<()> {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
 
     let mut flags = SessionFlags::new();
 
@@ -508,7 +489,7 @@ fn get_session_info_test() -> Result<()> {
             SessionState::RO_PUBLIC_SESSION
         );
 
-        session.login(UserType::User, user_pin)?;
+        session.login(UserType::User, Some(USER_PIN))?;
         let session_info = session.get_session_info()?;
         assert_eq!(session_info.flags(), flags);
         assert_eq!(session_info.slot_id(), slot);
@@ -517,7 +498,7 @@ fn get_session_info_test() -> Result<()> {
             SessionState::RO_USER_FUNCTIONS
         );
         session.logout()?;
-        if let Err(cryptoki::Error::Pkcs11(rv_error)) = session.login(UserType::So, so_pin) {
+        if let Err(cryptoki::Error::Pkcs11(rv_error)) = session.login(UserType::So, Some(SO_PIN)) {
             assert_eq!(rv_error, RvError::SessionReadOnlyExists)
         } else {
             panic!("Should error when attempting to log in as CKU_SO on a read-only session");
@@ -535,7 +516,7 @@ fn get_session_info_test() -> Result<()> {
         SessionState::RW_PUBLIC_SESSION
     );
 
-    session.login(UserType::User, user_pin)?;
+    session.login(UserType::User, Some(USER_PIN))?;
     let session_info = session.get_session_info()?;
     assert_eq!(session_info.flags(), flags);
     assert_eq!(session_info.slot_id(), slot);
@@ -544,7 +525,7 @@ fn get_session_info_test() -> Result<()> {
         SessionState::RW_USER_FUNCTIONS
     );
     session.logout()?;
-    session.login(UserType::So, so_pin)?;
+    session.login(UserType::So, Some(SO_PIN))?;
     let session_info = session.get_session_info()?;
     assert_eq!(session_info.flags(), flags);
     assert_eq!(session_info.slot_id(), slot);
@@ -556,9 +537,7 @@ fn get_session_info_test() -> Result<()> {
 #[test]
 #[serial]
 fn generate_random_test() -> Result<()> {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
 
     let mut flags = SessionFlags::new();
 
@@ -584,20 +563,18 @@ fn generate_random_test() -> Result<()> {
 #[test]
 #[serial]
 fn set_pin_test() -> Result<()> {
-    let user_pin = "fedcba";
     let new_user_pin = "123456";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
 
     let mut flags = SessionFlags::new();
 
     let _ = flags.set_serial_session(true).set_rw_session(true);
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
-    session.login(UserType::User, user_pin)?;
-    session.set_pin(user_pin, new_user_pin)?;
+    session.login(UserType::User, Some(USER_PIN))?;
+    session.set_pin(USER_PIN, new_user_pin)?;
     session.logout()?;
-    session.login(UserType::User, new_user_pin)?;
+    session.login(UserType::User, Some(new_user_pin))?;
 
     Ok(())
 }
@@ -605,9 +582,7 @@ fn set_pin_test() -> Result<()> {
 #[test]
 #[serial]
 fn get_attribute_info_test() -> Result<()> {
-    let user_pin = "fedcba";
-    let so_pin = "abcdef";
-    let (pkcs11, slot) = init_pins(so_pin, user_pin);
+    let (pkcs11, slot) = init_pins();
 
     let mut flags = SessionFlags::new();
     let _ = flags.set_rw_session(true).set_serial_session(true);
@@ -616,7 +591,7 @@ fn get_attribute_info_test() -> Result<()> {
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
     // log in the session
-    session.login(UserType::User, user_pin)?;
+    session.login(UserType::User, Some(USER_PIN))?;
 
     // get mechanism
     let mechanism = Mechanism::RsaPkcsKeyPairGen;

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -8,6 +8,7 @@ use cryptoki::types::mechanism::Mechanism;
 use cryptoki::types::object::{Attribute, AttributeInfo, AttributeType, KeyType, ObjectClass};
 use cryptoki::types::session::{SessionState, UserType};
 use cryptoki::types::SessionFlags;
+use cryptoki::Error;
 use serial_test::serial;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -27,7 +28,9 @@ type Result<T> = std::result::Result<T, ErrorWithStacktrace>;
 #[test]
 #[serial]
 fn sign_verify() -> Result<()> {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -37,7 +40,7 @@ fn sign_verify() -> Result<()> {
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
     // log in the session
-    session.login(UserType::User)?;
+    session.login(UserType::User, user_pin)?;
 
     // get mechanism
     let mechanism = Mechanism::RsaPkcsKeyPairGen;
@@ -79,7 +82,9 @@ fn sign_verify() -> Result<()> {
 #[test]
 #[serial]
 fn encrypt_decrypt() -> Result<()> {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -89,7 +94,7 @@ fn encrypt_decrypt() -> Result<()> {
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
     // log in the session
-    session.login(UserType::User)?;
+    session.login(UserType::User, user_pin)?;
 
     // get mechanism
     let mechanism = Mechanism::RsaPkcsKeyPairGen;
@@ -138,7 +143,9 @@ fn encrypt_decrypt() -> Result<()> {
 #[test]
 #[serial]
 fn derive_key() -> Result<()> {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -148,7 +155,7 @@ fn derive_key() -> Result<()> {
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
     // log in the session
-    session.login(UserType::User)?;
+    session.login(UserType::User, user_pin)?;
 
     // get mechanism
     let mechanism = Mechanism::EccKeyPairGen;
@@ -233,7 +240,9 @@ fn derive_key() -> Result<()> {
 #[test]
 #[serial]
 fn import_export() -> Result<()> {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -243,7 +252,7 @@ fn import_export() -> Result<()> {
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
     // log in the session
-    session.login(UserType::User)?;
+    session.login(UserType::User, user_pin)?;
 
     let public_exponent: Vec<u8> = vec![0x01, 0x00, 0x01];
     let modulus = vec![0xFF; 1024];
@@ -294,7 +303,9 @@ fn import_export() -> Result<()> {
 #[test]
 #[serial]
 fn get_token_info() -> Result<()> {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
     let info = pkcs11.get_token_info(slot)?;
     assert_eq!("SoftHSM project", info.manufacturer_id());
 
@@ -304,7 +315,9 @@ fn get_token_info() -> Result<()> {
 #[test]
 #[serial]
 fn wrap_and_unwrap_key() {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
     // set flags
     let mut flags = SessionFlags::new();
     let _ = flags.set_rw_session(true).set_serial_session(true);
@@ -313,7 +326,7 @@ fn wrap_and_unwrap_key() {
     let session = pkcs11.open_session_no_callback(slot, flags).unwrap();
 
     // log in the session
-    session.login(UserType::User).unwrap();
+    session.login(UserType::User, user_pin).unwrap();
 
     let key_to_be_wrapped_template = vec![
         Attribute::Token(true.into()),
@@ -393,7 +406,9 @@ fn wrap_and_unwrap_key() {
 fn login_feast() {
     const SESSIONS: usize = 100;
 
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -406,12 +421,30 @@ fn login_feast() {
         let pkcs11 = pkcs11.clone();
         threads.push(thread::spawn(move || {
             let session = pkcs11.open_session_no_callback(slot, flags).unwrap();
-            session.login(UserType::User).unwrap();
-            session.login(UserType::User).unwrap();
-            session.login(UserType::User).unwrap();
-            session.logout().unwrap();
-            session.logout().unwrap();
-            session.logout().unwrap();
+            match session.login(UserType::User, user_pin) {
+                Ok(_) | Err(Error::Pkcs11(RvError::UserAlreadyLoggedIn)) => {}
+                Err(e) => panic!("Bad error response: {}", e),
+            }
+            match session.login(UserType::User, user_pin) {
+                Ok(_) | Err(Error::Pkcs11(RvError::UserAlreadyLoggedIn)) => {}
+                Err(e) => panic!("Bad error response: {}", e),
+            }
+            match session.login(UserType::User, user_pin) {
+                Ok(_) | Err(Error::Pkcs11(RvError::UserAlreadyLoggedIn)) => {}
+                Err(e) => panic!("Bad error response: {}", e),
+            }
+            match session.logout() {
+                Ok(_) | Err(Error::Pkcs11(RvError::UserNotLoggedIn)) => {}
+                Err(e) => panic!("Bad error response: {}", e),
+            }
+            match session.logout() {
+                Ok(_) | Err(Error::Pkcs11(RvError::UserNotLoggedIn)) => {}
+                Err(e) => panic!("Bad error response: {}", e),
+            }
+            match session.logout() {
+                Ok(_) | Err(Error::Pkcs11(RvError::UserNotLoggedIn)) => {}
+                Err(e) => panic!("Bad error response: {}", e),
+            }
         }));
     }
 
@@ -423,7 +456,9 @@ fn login_feast() {
 #[test]
 #[serial]
 fn get_info_test() -> Result<()> {
-    let (pkcs11, _) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, _) = init_pins(so_pin, user_pin);
     let info = pkcs11.get_library_info()?;
 
     assert_eq!(info.cryptoki_version().major(), 2);
@@ -435,7 +470,9 @@ fn get_info_test() -> Result<()> {
 #[test]
 #[serial]
 fn get_slot_info_test() -> Result<()> {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
     let slot_info = pkcs11.get_slot_info(slot)?;
     assert!(slot_info.flags().token_present());
     assert!(!slot_info.flags().hardware_slot());
@@ -447,7 +484,9 @@ fn get_slot_info_test() -> Result<()> {
 #[test]
 #[serial]
 fn get_session_info_test() -> Result<()> {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
 
     let mut flags = SessionFlags::new();
 
@@ -469,7 +508,7 @@ fn get_session_info_test() -> Result<()> {
             SessionState::RO_PUBLIC_SESSION
         );
 
-        session.login(UserType::User)?;
+        session.login(UserType::User, user_pin)?;
         let session_info = session.get_session_info()?;
         assert_eq!(session_info.flags(), flags);
         assert_eq!(session_info.slot_id(), slot);
@@ -478,7 +517,7 @@ fn get_session_info_test() -> Result<()> {
             SessionState::RO_USER_FUNCTIONS
         );
         session.logout()?;
-        if let Err(cryptoki::Error::Pkcs11(rv_error)) = session.login(UserType::So) {
+        if let Err(cryptoki::Error::Pkcs11(rv_error)) = session.login(UserType::So, so_pin) {
             assert_eq!(rv_error, RvError::SessionReadOnlyExists)
         } else {
             panic!("Should error when attempting to log in as CKU_SO on a read-only session");
@@ -496,7 +535,7 @@ fn get_session_info_test() -> Result<()> {
         SessionState::RW_PUBLIC_SESSION
     );
 
-    session.login(UserType::User)?;
+    session.login(UserType::User, user_pin)?;
     let session_info = session.get_session_info()?;
     assert_eq!(session_info.flags(), flags);
     assert_eq!(session_info.slot_id(), slot);
@@ -505,7 +544,7 @@ fn get_session_info_test() -> Result<()> {
         SessionState::RW_USER_FUNCTIONS
     );
     session.logout()?;
-    session.login(UserType::So)?;
+    session.login(UserType::So, so_pin)?;
     let session_info = session.get_session_info()?;
     assert_eq!(session_info.flags(), flags);
     assert_eq!(session_info.slot_id(), slot);
@@ -517,7 +556,9 @@ fn get_session_info_test() -> Result<()> {
 #[test]
 #[serial]
 fn generate_random_test() -> Result<()> {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
 
     let mut flags = SessionFlags::new();
 
@@ -543,19 +584,20 @@ fn generate_random_test() -> Result<()> {
 #[test]
 #[serial]
 fn set_pin_test() -> Result<()> {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let new_user_pin = "123456";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
 
     let mut flags = SessionFlags::new();
 
     let _ = flags.set_serial_session(true).set_rw_session(true);
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
-    pkcs11.set_pin(slot, "1234")?;
-    session.login(UserType::User)?;
-    session.set_pin("1234", "5678")?;
-    session.logout();
-    pkcs11.set_pin(slot, "5678");
-    session.login(UserType::User)?;
+    session.login(UserType::User, user_pin)?;
+    session.set_pin(user_pin, new_user_pin)?;
+    session.logout()?;
+    session.login(UserType::User, new_user_pin)?;
 
     Ok(())
 }
@@ -563,7 +605,9 @@ fn set_pin_test() -> Result<()> {
 #[test]
 #[serial]
 fn get_attribute_info_test() -> Result<()> {
-    let (pkcs11, slot) = init_pins();
+    let user_pin = "fedcba";
+    let so_pin = "abcdef";
+    let (pkcs11, slot) = init_pins(so_pin, user_pin);
 
     let mut flags = SessionFlags::new();
     let _ = flags.set_rw_session(true).set_serial_session(true);
@@ -572,7 +616,7 @@ fn get_attribute_info_test() -> Result<()> {
     let session = pkcs11.open_session_no_callback(slot, flags)?;
 
     // log in the session
-    session.login(UserType::User)?;
+    session.login(UserType::User, user_pin)?;
 
     // get mechanism
     let mechanism = Mechanism::RsaPkcsKeyPairGen;

--- a/cryptoki/tests/common.rs
+++ b/cryptoki/tests/common.rs
@@ -7,7 +7,7 @@ use cryptoki::types::SessionFlags;
 use cryptoki::Pkcs11;
 use std::env;
 
-pub fn init_pins() -> (Pkcs11, Slot) {
+pub fn init_pins(so_pin: &str, user_pin: &str) -> (Pkcs11, Slot) {
     let pkcs11 = Pkcs11::new(
         env::var("PKCS11_SOFTHSM2_MODULE")
             .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
@@ -20,8 +20,7 @@ pub fn init_pins() -> (Pkcs11, Slot) {
     // find a slot, get the first one
     let slot = pkcs11.get_slots_with_token().unwrap().remove(0);
 
-    pkcs11.init_token(slot, "1234", "Test Token").unwrap();
-    pkcs11.set_pin(slot, "1234").unwrap();
+    pkcs11.init_token(slot, so_pin, "Test Token").unwrap();
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -31,8 +30,8 @@ pub fn init_pins() -> (Pkcs11, Slot) {
         // open a session
         let session = pkcs11.open_session_no_callback(slot, flags).unwrap();
         // log in the session
-        session.login(UserType::So).unwrap();
-        session.init_pin("1234").unwrap();
+        session.login(UserType::So, so_pin).unwrap();
+        session.init_pin(user_pin).unwrap();
     }
 
     (pkcs11, slot)

--- a/cryptoki/tests/common.rs
+++ b/cryptoki/tests/common.rs
@@ -7,7 +7,12 @@ use cryptoki::types::SessionFlags;
 use cryptoki::Pkcs11;
 use std::env;
 
-pub fn init_pins(so_pin: &str, user_pin: &str) -> (Pkcs11, Slot) {
+// The default user pin
+pub static USER_PIN: &str = "fedcba";
+// The default SO pin
+pub static SO_PIN: &str = "abcdef";
+
+pub fn init_pins() -> (Pkcs11, Slot) {
     let pkcs11 = Pkcs11::new(
         env::var("PKCS11_SOFTHSM2_MODULE")
             .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
@@ -20,7 +25,7 @@ pub fn init_pins(so_pin: &str, user_pin: &str) -> (Pkcs11, Slot) {
     // find a slot, get the first one
     let slot = pkcs11.get_slots_with_token().unwrap().remove(0);
 
-    pkcs11.init_token(slot, so_pin, "Test Token").unwrap();
+    pkcs11.init_token(slot, SO_PIN, "Test Token").unwrap();
 
     // set flags
     let mut flags = SessionFlags::new();
@@ -30,8 +35,8 @@ pub fn init_pins(so_pin: &str, user_pin: &str) -> (Pkcs11, Slot) {
         // open a session
         let session = pkcs11.open_session_no_callback(slot, flags).unwrap();
         // log in the session
-        session.login(UserType::So, so_pin).unwrap();
-        session.init_pin(user_pin).unwrap();
+        session.login(UserType::So, Some(SO_PIN)).unwrap();
+        session.init_pin(USER_PIN).unwrap();
     }
 
     (pkcs11, slot)


### PR DESCRIPTION
- Removed the PIN and session storage from `Pkcs11`
  - Allow the cryptoki token to maintain state
- Removed methods in `Pkcs11` that handled PIN storage
- Added `pin` as an argument to `login`
- Removed calling `logout` when a `Session` is `Drop`ed
- Updated tests

Signed-off-by: Michael J Boquard <michael.j.boquard@gmail.com>