### PR TITLE
Suppress null pointer deref warnings

### DIFF
--- a/cryptoki-sys/src/lib.rs
+++ b/cryptoki-sys/src/lib.rs
@@ -8,6 +8,10 @@
 #![allow(clippy::string_lit_as_bytes)]
 // Public items exportedby this crate should match the C style
 #![allow(clippy::upper_case_acronyms)]
+// Suppress warnings from bindgen-generated code
+// Remove on resolution of
+// https://github.com/rust-lang/rust-bindgen/issues/1651
+#![allow(deref_nullptr)]
 
 // For supported targets: use the generated and committed bindings.
 #[cfg(all(


### PR DESCRIPTION
This is a known issue with bindgen under heavy discussion, but doesn't look like it will be resolved soon. This attribute suppresses genuine warnings about undefined behavior in a pattern generated by bindgen many, many times. It should be removed when the bindgen issue is resolved.

Until then, it obscures other helpful warnings and errors.

See: rust-lang/rust-bindgen#1651