### PR TITLE
Bump bindgen for version 0.2.x of crate

### DIFF
--- a/cryptoki-sys/Cargo.toml
+++ b/cryptoki-sys/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/parallaxsecond/rust-cryptoki"
 documentation = "https://docs.rs/crate/cryptoki"
 
 [build-dependencies]
-bindgen = { version = "0.57.0", optional = true }
+bindgen = { version = "0.59.1", optional = true }
 target-lexicon = "0.12.0"
 
 [dependencies]


### PR DESCRIPTION
I've created a separate branch for the `0.2.x` versions of the crate, with the hope of using that for Parsec until we can update to `0.3.0`. A new release is needed on our side specifically for an update of the `bindgen` dependency, which this PR addresses. However, I plan to also update the committed bindings, hence this PR being a draft. This plan includes a bash script for regenerating those bindings when needed.

cc. @vkkoskie 