### PR TITLE
Bump version numbers for cryptoki v0.2.1

### DIFF
--- a/cryptoki-sys/Cargo.toml
+++ b/cryptoki-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptoki-sys"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Contributors to the Parsec project"]
 edition = '2018'
 description = "FFI wrapper around the PKCS #11 API"

--- a/cryptoki/Cargo.toml
+++ b/cryptoki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptoki"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Contributors to the Parsec project"]
 edition = '2018'
 description = "Rust-native wrapper around the PKCS #11 API"
@@ -17,7 +17,7 @@ log = "0.4.14"
 derivative = "2.2.0"
 secrecy = "0.7.0"
 psa-crypto = { version = "0.9.0", default-features = false, optional = true }
-cryptoki-sys = { path = "../cryptoki-sys", version = "0.1.2" }
+cryptoki-sys = { path = "../cryptoki-sys", version = "0.1.3" }
 
 [dev-dependencies]
 num-traits = "0.2.14"


### PR DESCRIPTION
As I've mentioned in #82 , I'll be porting the changes to `cryptoki-sys` to the `main` branch as well, after this release is done. This is just in preparation of a new release of `cryptoki`.

I think in the long run the `cryptoki-0.2.x` branch will stay as is.