### PR TITLE
Remove serial_test_derive from deps

### DIFF
--- a/cryptoki/Cargo.toml
+++ b/cryptoki/Cargo.toml
@@ -23,7 +23,6 @@ cryptoki-sys = { path = "../cryptoki-sys", version = "0.1.3" }
 num-traits = "0.2.14"
 hex = "0.4.3"
 serial_test = "0.5.1"
-serial_test_derive = "0.5.1"
 
 [features]
 psa-crypto-conversions = ["psa-crypto"]


### PR DESCRIPTION
`serial_test` since [0.3](https://github.com/palfrey/serial_test/releases/tag/v0.3.0) includes `serial_test_derive` and lets you use the macro without needing to directly include `serial_test_derive`