### PR TITLE
session_management: Add ability to login with raw bytes

### DIFF
--- a/cryptoki/src/session/mod.rs
+++ b/cryptoki/src/session/mod.rs
@@ -100,6 +100,22 @@ impl Session {
         session_management::login(self, user_type, pin)
     }
 
+    /// Logs a session in using a slice of raw bytes as a PIN. Some dongle drivers allow
+    /// non UTF-8 characters in the PIN and as a result, we aren't guaranteed that we can
+    /// pass in a UTF-8 string to login. Therefore, it's useful to be able to pass in raw bytes
+    /// rather than convert a UTF-8 string to bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `user_type` - The type of user to log in as
+    /// * `pin` - The PIN to use
+    ///
+    /// _NOTE: By passing `None` into `login`, you must ensure that the
+    /// [CKF_PROTECTED_AUTHENTICATION_PATH] flag is set in the `TokenFlags`._
+    pub fn login_with_raw(&self, user_type: UserType, pin: &[u8]) -> Result<()> {
+        session_management::login_with_raw(self, user_type, pin)
+    }
+
     /// Log a session out
     pub fn logout(&self) -> Result<()> {
         session_management::logout(self)

--- a/cryptoki/src/session/session_management.rs
+++ b/cryptoki/src/session/session_management.rs
@@ -38,6 +38,20 @@ pub(super) fn login(session: &Session, user_type: UserType, pin: Option<&str>) -
 
 // See public docs on stub in parent mod.rs
 #[inline(always)]
+pub(super) fn login_with_raw(session: &Session, user_type: UserType, pin: &[u8]) -> Result<()> {
+    unsafe {
+        Rv::from(get_pkcs11!(session.client(), C_Login)(
+            session.handle(),
+            user_type.into(),
+            pin.as_ptr() as *mut u8,
+            pin.len().try_into()?,
+        ))
+        .into_result()
+    }
+}
+
+// See public docs on stub in parent mod.rs
+#[inline(always)]
 pub(super) fn logout(session: &Session) -> Result<()> {
     unsafe { Rv::from(get_pkcs11!(session.client(), C_Logout)(session.handle())).into_result() }
 }


### PR DESCRIPTION
Rationale for this addition is identical to https://github.com/mheese/rust-pkcs11/pull/8. Some dongle drivers are insane and allow you to use invalid strings as a PIN. As a result we need a way to pass in a raw slice of bytes.