### PR TITLE
Fix CI error for x86_64-pc-windows-msvc

### DIFF
--- a/cryptoki/src/context/general_purpose.rs
+++ b/cryptoki/src/context/general_purpose.rs
@@ -36,14 +36,14 @@ pub(super) fn get_library_info(ctx: &Pkcs11) -> Result<Info> {
 }
 
 macro_rules! check_fn {
-    ($pkcs11:expr, $func_name:ident) => {
-        paste! { $pkcs11
+    ($pkcs11:expr, $func_name:ident) => {{
+        let func = paste! { $pkcs11
             .impl_
-            .function_list
-            .[< C_ $func_name >]
-            .is_some()
-        }
-    };
+                .function_list
+                .[<C_ $func_name>]
+        };
+        func.is_some()
+    }};
 }
 
 #[allow(clippy::enum_variant_names, missing_docs)]


### PR DESCRIPTION
Had a weird error happening when compiling for `x86_64-pc-windows-msvc`:

```
error: reference to packed field is unaligned                                                                                                                                                                                                                                               
   --> cryptoki/src/context/general_purpose.rs:46:30                                                                                                                                                                                                                                        
    |                                                                                                                                                                                                                                                                                       
46  |                     .is_some()                                                                                                                                                                                                                                                        
    |                              ^                                                                                                                                                                                                                                                        
...                                                                                                                                                                                                                                                                                         
188 |         Function::GenerateKeyPair => check_fn!(ctx, GenerateKeyPair),                                                                                                                                                                                                                 
    |                                      ------------------------------- in this macro invocation                                                                                                                                                                                         
    |                                                                                                                                                                                                                                                                                       
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!                                                                                                                                                       
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>                                                                                                                                                                                         
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)                                                                                                                     
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)                                                           
    = note: this error originates in the macro `check_fn` (in Nightly builds, run with -Z macro-backtrace for more info)                                                                                                                                                                    
                                                                                                                                                                                                                                                                                            
```

This applies the tip and move things in a local variable.