### PR TITLE
Make separate constructors for RO/RW sessions

### DIFF
--- a/cryptoki/src/context/mod.rs
+++ b/cryptoki/src/context/mod.rs
@@ -168,9 +168,20 @@ impl Pkcs11 {
         slot_token_management::get_mechanism_info(self, slot, type_)
     }
 
-    /// Open a new session with no callback set
-    pub fn open_session_no_callback(&self, slot_id: Slot, read_write: bool) -> Result<Session> {
-        session_management::open_session_no_callback(self, slot_id, read_write)
+    /// Open a new Read-Only session
+    ///
+    /// For a Read-Write session, use `open_rw_session`
+    ///
+    /// Note: No callback is set when opening the session.
+    pub fn open_ro_session(&self, slot_id: Slot) -> Result<Session> {
+        session_management::open_session_no_callback(self, slot_id, false)
+    }
+
+    /// Open a new Read/Write session
+    ///
+    /// Note: No callback is set when opening the session.
+    pub fn open_rw_session(&self, slot_id: Slot) -> Result<Session> {
+        session_management::open_session_no_callback(self, slot_id, true)
     }
 
     /// Check whether a given PKCS11 spec-defined function is supported by this implementation

--- a/cryptoki/src/context/mod.rs
+++ b/cryptoki/src/context/mod.rs
@@ -174,14 +174,14 @@ impl Pkcs11 {
     ///
     /// Note: No callback is set when opening the session.
     pub fn open_ro_session(&self, slot_id: Slot) -> Result<Session> {
-        session_management::open_session_no_callback(self, slot_id, false)
+        session_management::open_session(self, slot_id, false)
     }
 
     /// Open a new Read/Write session
     ///
     /// Note: No callback is set when opening the session.
     pub fn open_rw_session(&self, slot_id: Slot) -> Result<Session> {
-        session_management::open_session_no_callback(self, slot_id, true)
+        session_management::open_session(self, slot_id, true)
     }
 
     /// Check whether a given PKCS11 spec-defined function is supported by this implementation

--- a/cryptoki/src/context/session_management.rs
+++ b/cryptoki/src/context/session_management.rs
@@ -11,11 +11,7 @@ use crate::slot::Slot;
 use std::convert::TryInto;
 // See public docs on stub in parent mod.rs
 #[inline(always)]
-pub(super) fn open_session_no_callback(
-    ctx: &Pkcs11,
-    slot_id: Slot,
-    read_write: bool,
-) -> Result<Session> {
+pub(super) fn open_session(ctx: &Pkcs11, slot_id: Slot, read_write: bool) -> Result<Session> {
     let mut session_handle = 0;
 
     let flags = if read_write {

--- a/cryptoki/src/session/mod.rs
+++ b/cryptoki/src/session/mod.rs
@@ -175,7 +175,7 @@ impl Session {
     /// pkcs11.initialize(CInitializeArgs::OsThreads).unwrap();
     /// let slot = pkcs11.get_slots_with_token().unwrap().remove(0);
     ///
-    /// let session = pkcs11.open_session_no_callback(slot, true).unwrap();
+    /// let session = pkcs11.open_ro_session(slot).unwrap();
     /// session.login(UserType::User, Some("fedcba"));
     ///
     /// let empty_attrib= vec![];

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -751,7 +751,7 @@ fn ro_rw_session_test() -> Result<()> {
         ro_session.login(UserType::User, Some(USER_PIN))?;
 
         // generate a key pair
-        // This should NOT work using the Read/Write session
+        // This should NOT work using the Read-Only session
         let e = ro_session.create_object(&template).unwrap_err();
 
         if let Error::Pkcs11(RvError::SessionReadOnly) = e {

--- a/cryptoki/tests/common.rs
+++ b/cryptoki/tests/common.rs
@@ -27,7 +27,7 @@ pub fn init_pins() -> (Pkcs11, Slot) {
 
     {
         // open a session
-        let session = pkcs11.open_session_no_callback(slot, true).unwrap();
+        let session = pkcs11.open_rw_session(slot).unwrap();
         // log in the session
         session.login(UserType::So, Some(SO_PIN)).unwrap();
         session.init_pin(USER_PIN).unwrap();


### PR DESCRIPTION
The previous constructor took a boolean argument which made it difficult
to understand what the user code would be doing. That constructor is now
two separate functions, one for RO sessions, one for RW sessions. The
`_no_callback` part of the method name was also removed and added to the
documentation instead.

cc @ximon18 