### PR TITLE
Make RSA OAEP and ECDH1 safe using lifetime parameters

### DIFF
--- a/cryptoki/src/mechanism/elliptic_curve.rs
+++ b/cryptoki/src/mechanism/elliptic_curve.rs
@@ -1,12 +1,10 @@
 //! ECDH mechanism types
 
-use crate::error::{Error, Result};
 use crate::types::Ulong;
 use cryptoki_sys::*;
-use log::error;
-use std::convert::TryFrom;
-use std::ffi::c_void;
-use std::ops::Deref;
+use std::convert::TryInto;
+use std::marker::PhantomData;
+use std::ptr;
 
 /// ECDH derivation parameters.
 ///
@@ -16,67 +14,86 @@ use std::ops::Deref;
 /// ANSI X9.63, where each party contributes one key pair all using
 /// the same EC domain parameters.
 ///
-/// This structure wraps CK_ECDH1_DERIVE_PARAMS structure.
+/// This structure wraps a CK_ECDH1_DERIVE_PARAMS structure.
 #[derive(Copy, Debug, Clone)]
 #[repr(C)]
-pub struct Ecdh1DeriveParams {
+pub struct Ecdh1DeriveParams<'a> {
     /// Key derivation function
-    pub kdf: EcKdfType,
+    kdf: CK_EC_KDF_TYPE,
     /// Length of the optional shared data used by some of the key
     /// derivation functions
-    pub shared_data_len: Ulong,
+    shared_data_len: Ulong,
     /// Address of the optional data or `std::ptr::null()` of there is
     /// no shared data
-    pub shared_data: *const c_void,
+    shared_data: *const u8,
     /// Length of the other party's public key
-    pub public_data_len: Ulong,
+    public_data_len: Ulong,
     /// Pointer to the other party public key
-    pub public_data: *const c_void,
+    public_data: *const u8,
+    /// Marker type to ensure we don't outlive shared and public data
+    _marker: PhantomData<&'a [u8]>,
+}
+
+impl<'a> Ecdh1DeriveParams<'a> {
+    /// Construct ECDH derivation parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `kdf` - The key derivation function to use.
+    ///
+    /// * `public_data` - The other party's public key.  A token MUST be able
+    /// to accept this value encoded as a raw octet string (as per section
+    /// A.5.2 of [ANSI X9.62]).  A token MAY, in addition, support accepting
+    /// this value as a DER-encoded ECPoint (as per section E.6 of [ANSI
+    /// X9.62]) i.e. the same as a CKA_EC_POINT encoding.  The calling
+    /// application is responsible for converting the offered public key to the
+    /// compressed or uncompressed forms of these encodings if the token does
+    /// not support the offered form.
+    pub fn new(kdf: EcKdf<'a>, public_data: &'a [u8]) -> Self {
+        Self {
+            kdf: kdf.kdf_type,
+            shared_data_len: kdf
+                .shared_data
+                .map_or(0, <[u8]>::len)
+                .try_into()
+                .expect("usize can not fit in CK_ULONG"),
+            shared_data: kdf.shared_data.map_or(ptr::null(), <[u8]>::as_ptr),
+            public_data_len: public_data
+                .len()
+                .try_into()
+                .expect("usize can not fit in CK_ULONG"),
+            public_data: public_data.as_ptr(),
+            _marker: PhantomData,
+        }
+    }
 }
 
 /// Key Derivation Function applied to derive keying data from a shared secret.
 ///
 /// The key derivation function will be used by the EC key agreement schemes.
+///
+/// The lifetime parameter represents the lifetime of the shared data used by
+/// the KDF.  In the current version of this crate, only the null KDF is
+/// supported, which takes no shared data.  Therefore `'a` can always be inferred
+/// `'static`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(transparent)]
-pub struct EcKdfType {
-    val: CK_EC_KDF_TYPE,
+pub struct EcKdf<'a> {
+    kdf_type: CK_EC_KDF_TYPE,
+    shared_data: Option<&'a [u8]>,
 }
 
-impl EcKdfType {
+impl<'a> EcKdf<'a> {
     /// The null transformation. The derived key value is produced by
     /// taking bytes from the left of the agreed value. The new key
     /// size is limited to the size of the agreed value.
-    pub const NULL: EcKdfType = EcKdfType { val: CKD_NULL };
-}
-
-impl Deref for EcKdfType {
-    type Target = CK_EC_KDF_TYPE;
-
-    fn deref(&self) -> &Self::Target {
-        &self.val
-    }
-}
-
-impl From<EcKdfType> for CK_EC_KDF_TYPE {
-    fn from(ec_kdf_type: EcKdfType) -> Self {
-        *ec_kdf_type
-    }
-}
-
-impl TryFrom<CK_EC_KDF_TYPE> for EcKdfType {
-    type Error = Error;
-
-    fn try_from(ec_kdf_type: CK_EC_KDF_TYPE) -> Result<Self> {
-        match ec_kdf_type {
-            CKD_NULL => Ok(EcKdfType::NULL),
-            other => {
-                error!(
-                    "Key derivation function type {} is not one of the valid values.",
-                    other
-                );
-                Err(Error::InvalidValue)
-            }
+    pub fn null() -> Self {
+        Self {
+            kdf_type: CKD_NULL,
+            shared_data: None,
         }
     }
+
+    // The intention here is to be able to support other methods with
+    // shared data, without it being a breaking change, by just adding
+    // additional constructors here.
 }

--- a/cryptoki/src/mechanism/mod.rs
+++ b/cryptoki/src/mechanism/mod.rs
@@ -599,7 +599,7 @@ impl TryFrom<CK_MECHANISM_TYPE> for MechanismType {
 #[derive(Copy, Debug, Clone)]
 #[non_exhaustive]
 /// Type defining a specific mechanism and its parameters
-pub enum Mechanism {
+pub enum Mechanism<'a> {
     // AES
     /// AES key gen mechanism
     AesKeyGen,
@@ -621,7 +621,7 @@ pub enum Mechanism {
     RsaPkcsPss(rsa::PkcsPssParams),
     /// Multi-purpose mechanism based on the RSA public-key cryptosystem and the OAEP block format
     /// defined in PKCS #1
-    RsaPkcsOaep(rsa::PkcsOaepParams),
+    RsaPkcsOaep(rsa::PkcsOaepParams<'a>),
     /// Multi-purpose mechanism based on the RSA public-key cryptosystem.  This is so-called "raw"
     /// RSA, as assumed in X.509.
     RsaX509,
@@ -695,7 +695,7 @@ pub enum Mechanism {
     Sha512RsaPkcsPss(rsa::PkcsPssParams),
 }
 
-impl Mechanism {
+impl Mechanism<'_> {
     /// Get the type of a mechanism
     pub fn mechanism_type(&self) -> MechanismType {
         match self {
@@ -747,7 +747,7 @@ impl Mechanism {
     }
 }
 
-impl From<&Mechanism> for CK_MECHANISM {
+impl From<&Mechanism<'_>> for CK_MECHANISM {
     fn from(mech: &Mechanism) -> Self {
         let mechanism = mech.mechanism_type().into();
         match mech {

--- a/cryptoki/src/mechanism/mod.rs
+++ b/cryptoki/src/mechanism/mod.rs
@@ -646,7 +646,7 @@ pub enum Mechanism<'a> {
     /// EC montgomery key pair generation
     EccMontgomeryKeyPairGen,
     /// ECDH
-    Ecdh1Derive(elliptic_curve::Ecdh1DeriveParams),
+    Ecdh1Derive(elliptic_curve::Ecdh1DeriveParams<'a>),
     /// ECDSA mechanism
     Ecdsa,
     /// ECDSA with SHA-1 mechanism

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -174,15 +174,8 @@ fn derive_key() -> Result<()> {
     };
 
     use cryptoki::mechanism::elliptic_curve::*;
-    use std::convert::TryInto;
 
-    let params = Ecdh1DeriveParams {
-        kdf: EcKdfType::NULL,
-        shared_data_len: 0_usize.try_into()?,
-        shared_data: std::ptr::null(),
-        public_data_len: (*ec_point).len().try_into()?,
-        public_data: ec_point.as_ptr() as *const std::ffi::c_void,
-    };
+    let params = Ecdh1DeriveParams::new(EcKdf::null(), &ec_point);
 
     let shared_secret = session.derive_key(
         &Mechanism::Ecdh1Derive(params),


### PR DESCRIPTION
This PR adds a lifetime parameter to `Mechanism`.  This allows the user to pass references to slices in places where the C interface to PKCS11 expects pointers and lengths.  This fixes #107, and makes ECDH1 safe as well.

The new interfaces have the same level of extensibility as the old interface, in the sense that we can add new KDFs or encoding parameter sources without it being a breaking change, but the user cannot add their own.