### PR TITLE
Update to remove const_err

### DIFF
--- a/cryptoki/src/lib.rs
+++ b/cryptoki/src/lib.rs
@@ -21,7 +21,6 @@
 // This list comes from
 // https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
 #![deny(bad_style,
-       const_err,
        dead_code,
        improper_ctypes,
        non_shorthand_field_patterns,


### PR DESCRIPTION
This PR only removed `const_err` since it will be a hard error in future: https://github.com/rust-lang/rust/issues/71800

Signed-off-by: Marcus de Lima <marcus.lima@azion.com>