### PR TITLE
Update to remove const_err lint

### DIFF
--- a/cryptoki/src/lib.rs
+++ b/cryptoki/src/lib.rs
@@ -21,7 +21,6 @@
 // This list comes from
 // https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
 #![deny(bad_style,
-       const_err,
        dead_code,
        improper_ctypes,
        non_shorthand_field_patterns,


### PR DESCRIPTION
This PR is exactly the same as #114 but rebased on top of `main` so that it builds successfully.