### PR TITLE
Implement PartialEq/Eq for Attribute

### DIFF
--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -403,7 +403,7 @@ impl TryFrom<CK_ATTRIBUTE_TYPE> for AttributeType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 /// Attribute value
 pub enum Attribute {

--- a/cryptoki/src/types.rs
+++ b/cryptoki/src/types.rs
@@ -109,6 +109,16 @@ impl std::fmt::Display for Date {
     }
 }
 
+impl PartialEq for Date {
+    fn eq(&self, other: &Self) -> bool {
+        self.date.year == other.date.year
+            && self.date.month == other.date.month
+            && self.date.day == other.date.day
+    }
+}
+
+impl Eq for Date {}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
 /// Unsigned value, at least 32 bits long


### PR DESCRIPTION
I'm (mis)using this crate to simplify creating a basic PKCS#11 implementation. For that being able to compare `Attribute`s is helpful.