### PR TITLE
fixup clippy errors

### DIFF
--- a/cryptoki/src/error/mod.rs
+++ b/cryptoki/src/error/mod.rs
@@ -54,14 +54,14 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::LibraryLoading(e) => write!(f, "libloading error ({})", e),
-            Error::Pkcs11(e) => write!(f, "PKCS11 error: {}", e),
+            Error::LibraryLoading(e) => write!(f, "libloading error ({e})"),
+            Error::Pkcs11(e) => write!(f, "PKCS11 error: {e}"),
             Error::NotSupported => write!(f, "Feature not supported"),
-            Error::TryFromInt(e) => write!(f, "Conversion between integers failed ({})", e),
-            Error::TryFromSlice(e) => write!(f, "Error converting slice to array ({})", e),
-            Error::ParseInt(e) => write!(f, "Error parsing string as integer ({})", e),
-            Error::Utf8(e) => write!(f, "Invalid UTF-8 ({})", e),
-            Error::NulError(e) => write!(f, "An interior nul byte was found ({})", e),
+            Error::TryFromInt(e) => write!(f, "Conversion between integers failed ({e})"),
+            Error::TryFromSlice(e) => write!(f, "Error converting slice to array ({e})"),
+            Error::ParseInt(e) => write!(f, "Error parsing string as integer ({e})"),
+            Error::Utf8(e) => write!(f, "Invalid UTF-8 ({e})"),
+            Error::NulError(e) => write!(f, "An interior nul byte was found ({e})"),
             Error::NullFunctionPointer => write!(f, "Calling a NULL function pointer"),
             Error::InvalidValue => write!(f, "The value is not one of the expected options"),
             Error::PinNotSet => write!(f, "Pin has not been set before trying to log in"),

--- a/cryptoki/src/mechanism/mechanism_info.rs
+++ b/cryptoki/src/mechanism/mechanism_info.rs
@@ -242,8 +242,8 @@ VERIFY_RECOVER | GENERATE | GENERATE_KEY_PAIR | WRAP | UNWRAP | DERIVE | \
 EXTENSION | EC_F_P | EC_F_2M | EC_ECPARAMETERS | EC_NAMEDCURVE | \
 EC_UNCOMPRESS | EC_COMPRESS";
         let all = MechanismInfoFlags::all();
-        let observed = format!("{:#?}", all);
-        println!("{}", observed);
+        let observed = format!("{all:#?}");
+        println!("{observed}");
         assert_eq!(observed, expected);
     }
 
@@ -259,7 +259,7 @@ EC_UNCOMPRESS | EC_COMPRESS";
     max_key_size: 4096,
     flags: (empty),
 }"#;
-        let observed = format!("{:#?}", info);
+        let observed = format!("{info:#?}");
         assert_eq!(observed, expected);
     }
 }

--- a/cryptoki/src/mechanism/mod.rs
+++ b/cryptoki/src/mechanism/mod.rs
@@ -587,7 +587,7 @@ impl MechanismType {
             CKM_EC_MONTGOMERY_KEY_PAIR_GEN => {
                 String::from(stringify!(CKM_EC_MONTGOMERY_KEY_PAIR_GEN))
             }
-            _ => format!("unknown {:08x}", mech),
+            _ => format!("unknown {mech:08x}"),
         }
     }
 }

--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -253,7 +253,7 @@ impl AttributeType {
             CKA_UNWRAP_TEMPLATE => String::from(stringify!(CKA_UNWRAP_TEMPLATE)),
             CKA_DERIVE_TEMPLATE => String::from(stringify!(CKA_DERIVE_TEMPLATE)),
             CKA_ALLOWED_MECHANISMS => String::from(stringify!(CKA_ALLOWED_MECHANISMS)),
-            _ => format!("unknown ({:08x})", val),
+            _ => format!("unknown ({val:08x})"),
         }
     }
 }
@@ -1017,7 +1017,7 @@ impl ObjectClass {
             CKO_DOMAIN_PARAMETERS => String::from(stringify!(CKO_DOMAIN_PARAMETERS)),
             CKO_MECHANISM => String::from(stringify!(CKO_MECHANISM)),
             CKO_OTP_KEY => String::from(stringify!(CKO_OTP_KEY)),
-            _ => format!("unknown ({:08x})", class),
+            _ => format!("unknown ({class:08x})"),
         }
     }
 }
@@ -1235,7 +1235,7 @@ impl KeyType {
             CKK_GOSTR3411 => String::from(stringify!(CKK_GOSTR3411)),
             CKK_GOST28147 => String::from(stringify!(CKK_GOST28147)),
             CKK_EC_EDWARDS => String::from(stringify!(CKK_EC_EDWARDS)),
-            _ => format!("unknown ({:08x})", key_type),
+            _ => format!("unknown ({key_type:08x})"),
         }
     }
 }
@@ -1349,7 +1349,7 @@ impl CertificateType {
             CKC_X_509 => String::from(stringify!(CKC_X_509)),
             CKC_X_509_ATTR_CERT => String::from(stringify!(CKC_X_509_ATTR_CERT)),
             CKC_WTLS => String::from(stringify!(CKC_WTLS)),
-            _ => format!("unknown ({:08x})", cert_type),
+            _ => format!("unknown ({cert_type:08x})"),
         }
     }
 }

--- a/cryptoki/src/session/session_info.rs
+++ b/cryptoki/src/session/session_info.rs
@@ -111,7 +111,7 @@ mod test {
     fn debug_flags_all() {
         let expected = "RW_SESSION | SERIAL_SESSION";
         let all = SessionInfoFlags::all();
-        let observed = format!("{:#?}", all);
+        let observed = format!("{all:#?}");
         assert_eq!(observed, expected);
     }
 
@@ -131,7 +131,7 @@ mod test {
     flags: (empty),
     device_error: 0,
 }"#;
-        let observed = format!("{:#?}", info);
+        let observed = format!("{info:#?}");
         assert_eq!(observed, expected);
     }
 }

--- a/cryptoki/src/slot/slot_info.rs
+++ b/cryptoki/src/slot/slot_info.rs
@@ -100,7 +100,7 @@ mod test {
     fn debug_flags_all() {
         let expected = "TOKEN_PRESENT | REMOVABLE_DEVICE | HW_SLOT";
         let all = SlotInfoFlags::all();
-        let observed = format!("{:#?}", all);
+        let observed = format!("{all:#?}");
         assert_eq!(observed, expected);
     }
 
@@ -126,7 +126,7 @@ mod test {
         minor: 0,
     },
 }"#;
-        let observed = format!("{:#?}", info);
+        let observed = format!("{info:#?}");
         assert_eq!(observed, expected);
     }
 }

--- a/cryptoki/src/slot/token_info.rs
+++ b/cryptoki/src/slot/token_info.rs
@@ -471,7 +471,7 @@ USER_PIN_COUNT_LOW | USER_PIN_FINAL_TRY | USER_PIN_LOCKED | \
 USER_PIN_TO_BE_CHANGED | SO_PIN_COUNT_LOW | SO_PIN_FINAL_TRY | SO_PIN_LOCKED | \
 SO_PIN_TO_BE_CHANGED | ERROR_STATE";
         let all = TokenInfoFlags::all();
-        let observed = format!("{:#?}", all);
+        let observed = format!("{all:#?}");
         assert_eq!(observed, expected);
     }
 
@@ -547,7 +547,7 @@ SO_PIN_TO_BE_CHANGED | ERROR_STATE";
         },
     ),
 }"#;
-        let observed = format!("{:#?}", info);
+        let observed = format!("{info:#?}");
         assert_eq!(observed, expected);
     }
 }

--- a/cryptoki/src/types.rs
+++ b/cryptoki/src/types.rs
@@ -105,7 +105,7 @@ impl std::fmt::Display for Date {
             .trim_end()
             .to_string();
 
-        write!(f, "Month: {}\nDay: {}\nYear: {}", month, day, year)
+        write!(f, "Month: {month}\nDay: {day}\nYear: {year}")
     }
 }
 
@@ -310,7 +310,7 @@ mod test {
     minute: 0,
     second: 0,
 }"#;
-        let observed = format!("{:#?}", UTC_TIME);
+        let observed = format!("{UTC_TIME:#?}");
         assert_eq!(observed, expected);
     }
     #[test]


### PR DESCRIPTION
Rust 1.67 brings new clippy suggestions, this causes CI errors.