### PR TITLE
Bump crates and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # Changelog
 
-## [cryptoki-0.4.0](https://github.com/parallaxsecond/rust-cryptoki/tree/cryptoki-0.4.0) (2021-11-22)
+## [cryptoki-sys-0.1.5](https://github.com/parallaxsecond/rust-cryptoki/tree/cryptoki-sys-0.1.5) (2023-03-13)
 
-[Full Changelog](https://github.com/parallaxsecond/rust-cryptoki/compare/cryptoki-0.2.0...cryptoki-0.4.0)
+[Full Changelog](https://github.com/parallaxsecond/rust-cryptoki/compare/cryptoki-0.3.1...cryptoki-sys-0.1.5)
+
+## [cryptoki-0.3.1](https://github.com/parallaxsecond/rust-cryptoki/tree/cryptoki-0.3.1) (2023-03-13)
+
+[Full Changelog](https://github.com/parallaxsecond/rust-cryptoki/compare/cryptoki-0.4.1...cryptoki-0.3.1)
+
+**Merged pull requests:**
+
+- Backport bindgen 0.63.0 changes to crypotki-0.3.x branch  [\#131](https://github.com/parallaxsecond/rust-cryptoki/pull/131) ([gowthamsk-arm](https://github.com/gowthamsk-arm))
+
+## [cryptoki-0.3.0](https://github.com/parallaxsecond/rust-cryptoki/tree/cryptoki-0.3.0) (2022-01-14)
+
+[Full Changelog](https://github.com/parallaxsecond/rust-cryptoki/compare/cryptoki-sys-0.1.3...cryptoki-0.3.0)
+
+## [cryptoki-sys-0.1.3](https://github.com/parallaxsecond/rust-cryptoki/tree/cryptoki-sys-0.1.3) (2022-01-14)
+
+[Full Changelog](https://github.com/parallaxsecond/rust-cryptoki/compare/cryptoki-0.2.0...cryptoki-sys-0.1.3)
 
 **Implemented enhancements:**
 
@@ -21,6 +37,7 @@
 
 **Merged pull requests:**
 
+- Version bump [\#79](https://github.com/parallaxsecond/rust-cryptoki/pull/79) ([ionut-arm](https://github.com/ionut-arm))
 - Suppress null pointer deref warnings [\#62](https://github.com/parallaxsecond/rust-cryptoki/pull/62) ([vkkoskie](https://github.com/vkkoskie))
 - Use rust's own bool type in abstraction crate [\#61](https://github.com/parallaxsecond/rust-cryptoki/pull/61) ([vkkoskie](https://github.com/vkkoskie))
 - Switch to inclusive bindgen naming [\#60](https://github.com/parallaxsecond/rust-cryptoki/pull/60) ([vkkoskie](https://github.com/vkkoskie))

--- a/cryptoki-sys/Cargo.toml
+++ b/cryptoki-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptoki-sys"
-version = "0.1.3"
+version = "0.1.5"
 authors = ["Contributors to the Parsec project"]
 edition = '2018'
 description = "FFI wrapper around the PKCS #11 API"

--- a/cryptoki/Cargo.toml
+++ b/cryptoki/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/crate/cryptoki"
 libloading = "0.7.0"
 log = "0.4.14"
 derivative = "2.2.0"
-psa-crypto = { version = "0.9.0", default-features = false, optional = true }
+psa-crypto = { version = "0.10.0", default-features = false, optional = true }
 cryptoki-sys = { path = "../cryptoki-sys", version = "0.1.3" }
 
 [dev-dependencies]

--- a/cryptoki/Cargo.toml
+++ b/cryptoki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptoki"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Contributors to the Parsec project"]
 edition = '2018'
 description = "Rust-native wrapper around the PKCS #11 API"
@@ -16,7 +16,7 @@ libloading = "0.7.0"
 log = "0.4.14"
 derivative = "2.2.0"
 psa-crypto = { version = "0.10.0", default-features = false, optional = true }
-cryptoki-sys = { path = "../cryptoki-sys", version = "0.1.3" }
+cryptoki-sys = { path = "../cryptoki-sys", version = "0.1.5" }
 
 [dev-dependencies]
 num-traits = "0.2.14"


### PR DESCRIPTION
This MR does the following things:

- Bump psa-crypto versions
- Update crytpoki crate version
- Add changelog

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>