### PR TITLE
Add documentation check to CI test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  docs:
+    name: Check documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check documentation
+        run: RUSTDOCFLAGS="-Dwarnings" cargo doc --document-private-items --no-deps
+
   build:
     name: Execute CI script
     runs-on: ubuntu-latest

--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -759,7 +759,7 @@ impl From<&Attribute> for CK_ATTRIBUTE {
     }
 }
 
-/// Private function standing in for TryInto<bool> for &[u8]
+/// Private function standing in for `TryInto<bool>` for `&[u8]`
 /// which can't be implemented through the actual trait because
 /// it and both types are external to this crate.
 /// NB from the specification: "In Cryptoki, the CK_BBOOL data type

--- a/cryptoki/src/session/random.rs
+++ b/cryptoki/src/session/random.rs
@@ -25,7 +25,7 @@ impl Session {
         Ok(())
     }
 
-    /// Generates random data and returns it as a Vec<u8>.  The length of the returned Vector will
+    /// Generates random data and returns it as a `Vec<u8>`.  The length of the returned Vector will
     /// be the amount of random requested, which is `random_len`.
     pub fn generate_random_vec(&self, random_len: u32) -> Result<Vec<u8>> {
         let mut result: Vec<u8> = vec![0; random_len as usize];


### PR DESCRIPTION
When recently building documentation for `cryptoki` with `cargo doc` I noticed a couple of small issues. This PR fixes them and adds the check to CI.