### PR TITLE
Add function name to errors and logs

### DIFF
--- a/cryptoki/src/context/general_purpose.rs
+++ b/cryptoki/src/context/general_purpose.rs
@@ -7,6 +7,7 @@ use crate::error::{Result, Rv};
 use cryptoki_sys::{CK_C_INITIALIZE_ARGS, CK_INFO};
 use paste::paste;
 use std::convert::TryFrom;
+use std::fmt::Display;
 
 // See public docs on stub in parent mod.rs
 #[inline(always)]
@@ -18,7 +19,7 @@ pub(super) fn initialize(ctx: &Pkcs11, init_args: CInitializeArgs) -> Result<()>
         Rv::from(get_pkcs11!(ctx, C_Initialize)(
             init_args_ptr as *mut CK_C_INITIALIZE_ARGS as *mut ::std::ffi::c_void,
         ))
-        .into_result()
+        .into_result(Function::Initialize)
     }
 }
 
@@ -27,7 +28,7 @@ pub(super) fn initialize(ctx: &Pkcs11, init_args: CInitializeArgs) -> Result<()>
 pub(super) fn get_library_info(ctx: &Pkcs11) -> Result<Info> {
     let mut info = CK_INFO::default();
     unsafe {
-        Rv::from(get_pkcs11!(ctx, C_GetInfo)(&mut info)).into_result()?;
+        Rv::from(get_pkcs11!(ctx, C_GetInfo)(&mut info)).into_result(Function::GetInfo)?;
         Info::try_from(info)
     }
 }
@@ -115,6 +116,12 @@ pub enum Function {
     GetFunctionStatus,
     CancelFunction,
     WaitForSlotEvent,
+}
+
+impl Display for Function {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Function::{:?}", self)
+    }
 }
 
 #[inline(always)]

--- a/cryptoki/src/context/mod.rs
+++ b/cryptoki/src/context/mod.rs
@@ -60,7 +60,7 @@ impl Pkcs11Impl {
                 .ok_or(Error::NullFunctionPointer)?(
                 ptr::null_mut()
             ))
-            .into_result()
+            .into_result(Function::Finalize)
         }
     }
 }
@@ -91,7 +91,8 @@ impl Pkcs11 {
                 cryptoki_sys::Pkcs11::new(filename.as_ref()).map_err(Error::LibraryLoading)?;
             let mut list = mem::MaybeUninit::uninit();
 
-            Rv::from(pkcs11_lib.C_GetFunctionList(list.as_mut_ptr())).into_result()?;
+            Rv::from(pkcs11_lib.C_GetFunctionList(list.as_mut_ptr()))
+                .into_result(Function::GetFunctionList)?;
 
             let list_ptr = *list.as_ptr();
 

--- a/cryptoki/src/context/session_management.rs
+++ b/cryptoki/src/context/session_management.rs
@@ -10,6 +10,8 @@ use crate::session::Session;
 use crate::slot::Slot;
 use std::convert::TryInto;
 
+use super::Function;
+
 impl Pkcs11 {
     #[inline(always)]
     fn open_session(&self, slot_id: Slot, read_write: bool) -> Result<Session> {
@@ -29,7 +31,7 @@ impl Pkcs11 {
                 None,
                 &mut session_handle,
             ))
-            .into_result()?;
+            .into_result(Function::OpenSession)?;
         }
 
         Ok(Session::new(session_handle, self.clone()))

--- a/cryptoki/src/error/mod.rs
+++ b/cryptoki/src/error/mod.rs
@@ -10,6 +10,8 @@ pub use rv_error::*;
 
 use std::fmt;
 
+use crate::context::Function;
+
 #[derive(Debug)]
 /// Main error type
 pub enum Error {
@@ -18,7 +20,7 @@ pub enum Error {
     LibraryLoading(libloading::Error),
 
     /// All PKCS#11 functions that return non-zero translate to this error.
-    Pkcs11(RvError),
+    Pkcs11(RvError, Function),
 
     /// This error marks a feature that is not yet supported by the PKCS11 Rust abstraction layer.
     NotSupported,
@@ -55,7 +57,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::LibraryLoading(e) => write!(f, "libloading error ({e})"),
-            Error::Pkcs11(e) => write!(f, "PKCS11 error: {e}"),
+            Error::Pkcs11(e, funct) => write!(f, "{funct}: PKCS11 error: {e}"),
             Error::NotSupported => write!(f, "Feature not supported"),
             Error::TryFromInt(e) => write!(f, "Conversion between integers failed ({e})"),
             Error::TryFromSlice(e) => write!(f, "Error converting slice to array ({e})"),
@@ -79,7 +81,7 @@ impl std::error::Error for Error {
             Error::ParseInt(e) => Some(e),
             Error::Utf8(e) => Some(e),
             Error::NulError(e) => Some(e),
-            Error::Pkcs11(_)
+            Error::Pkcs11(_, _)
             | Error::NotSupported
             | Error::NullFunctionPointer
             | Error::PinNotSet
@@ -128,12 +130,6 @@ impl From<std::ffi::NulError> for Error {
 impl From<std::convert::Infallible> for Error {
     fn from(_err: std::convert::Infallible) -> Error {
         unreachable!()
-    }
-}
-
-impl From<RvError> for Error {
-    fn from(rv_error: RvError) -> Self {
-        Error::Pkcs11(rv_error)
     }
 }
 

--- a/cryptoki/src/error/rv.rs
+++ b/cryptoki/src/error/rv.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Function types
 
+use crate::context::Function;
+
 use super::{Error, Result, RvError};
 use cryptoki_sys::*;
 use log::error;
@@ -128,10 +130,10 @@ impl From<CK_RV> for Rv {
 
 impl Rv {
     /// Convert the return value into a standard Result type
-    pub fn into_result(self) -> Result<()> {
+    pub fn into_result(self, function: Function) -> Result<()> {
         match self {
             Rv::Ok => Ok(()),
-            Rv::Error(rv_error) => Err(Error::Pkcs11(rv_error)),
+            Rv::Error(rv_error) => Err(Error::Pkcs11(rv_error, function)),
         }
     }
 }

--- a/cryptoki/src/session/decryption.rs
+++ b/cryptoki/src/session/decryption.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Decrypting data
 
+use crate::context::Function;
 use crate::error::{Result, Rv};
 use crate::mechanism::Mechanism;
 use crate::object::ObjectHandle;
@@ -26,7 +27,7 @@ impl Session {
                 &mut mechanism as CK_MECHANISM_PTR,
                 key.handle(),
             ))
-            .into_result()?;
+            .into_result(Function::DecryptInit)?;
         }
 
         // Get the output buffer length
@@ -39,7 +40,7 @@ impl Session {
                 std::ptr::null_mut(),
                 &mut data_len,
             ))
-            .into_result()?;
+            .into_result(Function::Decrypt)?;
         }
 
         let mut data = vec![0; data_len.try_into()?];
@@ -52,7 +53,7 @@ impl Session {
                 data.as_mut_ptr(),
                 &mut data_len,
             ))
-            .into_result()?;
+            .into_result(Function::Decrypt)?;
         }
 
         data.resize(data_len.try_into()?, 0);

--- a/cryptoki/src/session/digesting.rs
+++ b/cryptoki/src/session/digesting.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Digesting functions
 
+use crate::context::Function;
 use crate::error::{Result, Rv};
 use crate::mechanism::Mechanism;
 use crate::session::Session;
@@ -19,7 +20,7 @@ impl Session {
                 self.handle(),
                 &mut mechanism as CK_MECHANISM_PTR,
             ))
-            .into_result()?;
+            .into_result(Function::DigestInit)?;
         }
 
         // Get the output buffer length
@@ -31,7 +32,7 @@ impl Session {
                 std::ptr::null_mut(),
                 &mut digest_len,
             ))
-            .into_result()?;
+            .into_result(Function::Digest)?;
         }
 
         let mut digest = vec![0; digest_len.try_into()?];
@@ -44,7 +45,7 @@ impl Session {
                 digest.as_mut_ptr(),
                 &mut digest_len,
             ))
-            .into_result()?;
+            .into_result(Function::Digest)?;
         }
 
         digest.resize(digest_len.try_into()?, 0);

--- a/cryptoki/src/session/encryption.rs
+++ b/cryptoki/src/session/encryption.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Encrypting data
 
+use crate::context::Function;
 use crate::error::{Result, Rv};
 use crate::mechanism::Mechanism;
 use crate::object::ObjectHandle;
@@ -26,7 +27,7 @@ impl Session {
                 &mut mechanism as CK_MECHANISM_PTR,
                 key.handle(),
             ))
-            .into_result()?;
+            .into_result(Function::EncryptInit)?;
         }
 
         // Get the output buffer length
@@ -38,7 +39,7 @@ impl Session {
                 std::ptr::null_mut(),
                 &mut encrypted_data_len,
             ))
-            .into_result()?;
+            .into_result(Function::Encrypt)?;
         }
 
         let mut encrypted_data = vec![0; encrypted_data_len.try_into()?];
@@ -51,7 +52,7 @@ impl Session {
                 encrypted_data.as_mut_ptr(),
                 &mut encrypted_data_len,
             ))
-            .into_result()?;
+            .into_result(Function::Encrypt)?;
         }
 
         encrypted_data.resize(encrypted_data_len.try_into()?, 0);

--- a/cryptoki/src/session/key_management.rs
+++ b/cryptoki/src/session/key_management.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Key management functions
 
+use crate::context::Function;
 use crate::error::{Result, Rv};
 use crate::mechanism::Mechanism;
 use crate::object::{Attribute, ObjectHandle};
@@ -27,7 +28,7 @@ impl Session {
                 template.len().try_into()?,
                 &mut handle,
             ))
-            .into_result()?;
+            .into_result(Function::GenerateKey)?;
         }
 
         Ok(ObjectHandle::new(handle))
@@ -58,7 +59,7 @@ impl Session {
                 &mut pub_handle,
                 &mut priv_handle,
             ))
-            .into_result()?;
+            .into_result(Function::GenerateKeyPair)?;
         }
 
         Ok((
@@ -86,7 +87,7 @@ impl Session {
                 template.len().try_into()?,
                 &mut handle,
             ))
-            .into_result()?;
+            .into_result(Function::DeriveKey)?;
         }
 
         Ok(ObjectHandle::new(handle))
@@ -111,7 +112,7 @@ impl Session {
                 std::ptr::null_mut(),
                 &mut wrapped_key_len,
             ))
-            .into_result()?;
+            .into_result(Function::WrapKey)?;
 
             let mut wrapped_key = vec![0; wrapped_key_len.try_into()?];
 
@@ -123,7 +124,7 @@ impl Session {
                 wrapped_key.as_mut_ptr(),
                 &mut wrapped_key_len,
             ))
-            .into_result()?;
+            .into_result(Function::WrapKey)?;
 
             Ok(wrapped_key)
         }
@@ -151,7 +152,7 @@ impl Session {
                 template.len().try_into()?,
                 &mut handle,
             ))
-            .into_result()?;
+            .into_result(Function::UnwrapKey)?;
         }
 
         Ok(ObjectHandle::new(handle))

--- a/cryptoki/src/session/random.rs
+++ b/cryptoki/src/session/random.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Functions used to generate random numbers
 
+use crate::context::Function;
 use crate::error::{Result, Rv};
 use crate::session::Session;
 use std::convert::TryInto;
@@ -20,7 +21,7 @@ impl Session {
                 random_data.as_ptr() as *mut u8,
                 random_data.len().try_into()?,
             ))
-            .into_result()?;
+            .into_result(Function::GenerateRandom)?;
         }
         Ok(())
     }
@@ -35,7 +36,7 @@ impl Session {
                 result.as_mut_ptr(),
                 random_len.try_into()?,
             ))
-            .into_result()?;
+            .into_result(Function::GenerateRandom)?;
         }
         Ok(result)
     }
@@ -48,7 +49,7 @@ impl Session {
                 seed.as_ptr() as *mut u8,
                 seed.len().try_into()?,
             ))
-            .into_result()?;
+            .into_result(Function::SeedRandom)?;
         }
         Ok(())
     }

--- a/cryptoki/src/session/signing_macing.rs
+++ b/cryptoki/src/session/signing_macing.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Signing and authentication functions
 
+use crate::context::Function;
 use crate::error::{Result, Rv};
 use crate::mechanism::Mechanism;
 use crate::object::ObjectHandle;
@@ -21,7 +22,7 @@ impl Session {
                 &mut mechanism as CK_MECHANISM_PTR,
                 key.handle(),
             ))
-            .into_result()?;
+            .into_result(Function::SignInit)?;
         }
 
         // Get the output buffer length
@@ -33,7 +34,7 @@ impl Session {
                 std::ptr::null_mut(),
                 &mut signature_len,
             ))
-            .into_result()?;
+            .into_result(Function::Sign)?;
         }
 
         let mut signature = vec![0; signature_len.try_into()?];
@@ -47,7 +48,7 @@ impl Session {
                 signature.as_mut_ptr(),
                 &mut signature_len,
             ))
-            .into_result()?;
+            .into_result(Function::Sign)?;
         }
 
         signature.resize(signature_len.try_into()?, 0);
@@ -71,7 +72,7 @@ impl Session {
                 &mut mechanism as CK_MECHANISM_PTR,
                 key.handle(),
             ))
-            .into_result()?;
+            .into_result(Function::VerifyInit)?;
         }
 
         unsafe {
@@ -82,7 +83,7 @@ impl Session {
                 signature.as_ptr() as *mut u8,
                 signature.len().try_into()?,
             ))
-            .into_result()
+            .into_result(Function::Verify)
         }
     }
 }

--- a/cryptoki/src/session/slot_token_management.rs
+++ b/cryptoki/src/session/slot_token_management.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Slot and token management functions
 
+use crate::context::Function;
 use crate::error::{Result, Rv};
 use crate::session::Session;
 use crate::types::AuthPin;
@@ -17,7 +18,7 @@ impl Session {
                 pin.expose_secret().as_ptr() as *mut u8,
                 pin.expose_secret().len().try_into()?,
             ))
-            .into_result()
+            .into_result(Function::InitPIN)
         }
     }
 
@@ -32,7 +33,7 @@ impl Session {
                 new_pin.expose_secret().as_ptr() as *mut u8,
                 new_pin.expose_secret().len().try_into()?,
             ))
-            .into_result()
+            .into_result(Function::SetPIN)
         }
     }
 }


### PR DESCRIPTION
Adding the name of the function that lead to a backend error to the log messages it generates and to the error returned to the client.

cc @ellerh 