### PR TITLE
Fix codespell action

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = .git,target,Cargo.lock
+ignore-words-list = crate,keypair

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,14 @@ on: [push, pull_request]
 
 jobs:
   # Use the following command to fix words locally:
-  # codespell --ignore-words-list "crate" --skip "*/target,*-sys" --write-changes
+  # codespell --write-changes
   check-spelling:
     name: Check spelling
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Check spelling
-        uses: codespell-project/actions-codespell@master
-        with:
-          ignore_words_list: "crate"
-          path: cryptoki
-          skip: "*/target,*-sys"
+        uses: codespell-project/actions-codespell@v1
 
   formatting:
     name: Check formatting

--- a/cryptoki-sys/README.md
+++ b/cryptoki-sys/README.md
@@ -9,7 +9,7 @@ This is the low-level wrapper crate for PKCS #11 exposing the bindgen types.
 
 ## Generating bindings
 
-The FFI bindings presented by this crate can be either those commited in the
+The FFI bindings presented by this crate can be either those committed in the
 crate under `src/bindings` or generated on the fly from the `pkcs11.h` file
 at build time. For generating the bindings at build time
 please enable the `generate-bindings` feature, as it is not enabled by default.

--- a/cryptoki-sys/pkcs11.h
+++ b/cryptoki-sys/pkcs11.h
@@ -860,7 +860,7 @@ typedef unsigned long ck_mechanism_type_t;
 
 #define CKM_VENDOR_DEFINED		((unsigned long) (1UL << 31))
 
-/* Ammendments */
+/* Amendments */
 #define CKM_SHA224			(0x255UL)
 #define CKM_SHA224_HMAC			(0x256UL)
 #define CKM_SHA224_HMAC_GENERAL		(0x257UL)


### PR DESCRIPTION
Previously the action did not checkout the repository and as such actually didn't do what it was supposed to.

This patch fixes all typos that accumulated over the time. Adds the checkout action and fixes the codespell version action to `v1`.

Additionally codespell settings have been moved to a file so that the `codespell` command line can be executed locally using the same settings as in the CI.