### PR TITLE
"fix" for clone-then-initialize problem

### DIFF
--- a/cryptoki/src/context/general_purpose.rs
+++ b/cryptoki/src/context/general_purpose.rs
@@ -10,7 +10,7 @@ use std::convert::TryFrom;
 
 // See public docs on stub in parent mod.rs
 #[inline(always)]
-pub(super) fn initialize(ctx: &mut Pkcs11, init_args: CInitializeArgs) -> Result<()> {
+pub(super) fn initialize(ctx: &Pkcs11, init_args: CInitializeArgs) -> Result<()> {
     // if no args are specified, library expects NULL
     let mut init_args = CK_C_INITIALIZE_ARGS::from(init_args);
     let init_args_ptr = &mut init_args;
@@ -19,9 +19,6 @@ pub(super) fn initialize(ctx: &mut Pkcs11, init_args: CInitializeArgs) -> Result
             init_args_ptr as *mut CK_C_INITIALIZE_ARGS as *mut ::std::ffi::c_void,
         ))
         .into_result()
-        .map(|_| {
-            ctx.initialized = true;
-        })
     }
 }
 

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 mod common;
 
-use crate::common::{SO_PIN, USER_PIN};
+use crate::common::{get_pkcs11, SO_PIN, USER_PIN};
 use common::init_pins;
 use cryptoki::error::{Error, RvError};
 use cryptoki::mechanism::aead::GcmParams;
@@ -679,13 +679,9 @@ fn is_fn_supported_test() {
 #[test]
 #[serial]
 fn is_initialized_test() {
-    use cryptoki::context::{CInitializeArgs, Pkcs11};
+    use cryptoki::context::CInitializeArgs;
 
-    let mut pkcs11 = Pkcs11::new(
-        std::env::var("PKCS11_SOFTHSM2_MODULE")
-            .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
-    )
-    .unwrap();
+    let pkcs11 = get_pkcs11();
 
     assert!(
         !pkcs11.is_initialized(),
@@ -705,6 +701,34 @@ fn is_initialized_test() {
         Err(e) => panic!("Got unexpected error when initializing: {}", e),
         Ok(()) => panic!("Initializing twice should not have been allowed"),
     }
+}
+
+#[test]
+#[serial]
+#[allow(clippy::redundant_clone)]
+fn test_clone_initialize() {
+    use cryptoki::context::CInitializeArgs;
+
+    let pkcs11 = get_pkcs11();
+
+    let clone = pkcs11.clone();
+    assert!(
+        !pkcs11.is_initialized(),
+        "Before initialize() it should not be initialized"
+    );
+    assert!(
+        !clone.is_initialized(),
+        "Before initialize() the clone should not be initialized"
+    );
+    pkcs11.initialize(CInitializeArgs::OsThreads).unwrap();
+    assert!(
+        pkcs11.is_initialized(),
+        "After initialize() it should be initialized"
+    );
+    assert!(
+        clone.is_initialized(),
+        "After initialize() the clone should be initialized"
+    );
 }
 
 #[test]

--- a/cryptoki/tests/common.rs
+++ b/cryptoki/tests/common.rs
@@ -11,12 +11,16 @@ pub static USER_PIN: &str = "fedcba";
 // The default SO pin
 pub static SO_PIN: &str = "abcdef";
 
-pub fn init_pins() -> (Pkcs11, Slot) {
-    let mut pkcs11 = Pkcs11::new(
+pub fn get_pkcs11() -> Pkcs11 {
+    Pkcs11::new(
         env::var("PKCS11_SOFTHSM2_MODULE")
             .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
     )
-    .unwrap();
+    .unwrap()
+}
+
+pub fn init_pins() -> (Pkcs11, Slot) {
+    let pkcs11 = get_pkcs11();
 
     // initialize the library
     pkcs11.initialize(CInitializeArgs::OsThreads).unwrap();


### PR DESCRIPTION
This PR fixes the problem with clone and initialize.

It adds more locking while PKCS11 is supposed to be thread safe. For me that doesn't feel right. I would deprecate or remove `is_initialized()`:

```rust
    #[deprecated]
    pub fn is_initialized(&self) -> bool {
        get_library_info(self).is_ok()
    }
```

