### PR TITLE
Deprecate is_initialized()

### DIFF
--- a/cryptoki/src/context/general_purpose.rs
+++ b/cryptoki/src/context/general_purpose.rs
@@ -10,7 +10,7 @@ use std::convert::TryFrom;
 
 // See public docs on stub in parent mod.rs
 #[inline(always)]
-pub(super) fn initialize(ctx: &mut Pkcs11, init_args: CInitializeArgs) -> Result<()> {
+pub(super) fn initialize(ctx: &Pkcs11, init_args: CInitializeArgs) -> Result<()> {
     // if no args are specified, library expects NULL
     let mut init_args = CK_C_INITIALIZE_ARGS::from(init_args);
     let init_args_ptr = &mut init_args;
@@ -19,9 +19,6 @@ pub(super) fn initialize(ctx: &mut Pkcs11, init_args: CInitializeArgs) -> Result
             init_args_ptr as *mut CK_C_INITIALIZE_ARGS as *mut ::std::ffi::c_void,
         ))
         .into_result()
-        .map(|_| {
-            ctx.initialized = true;
-        })
     }
 }
 

--- a/cryptoki/src/context/mod.rs
+++ b/cryptoki/src/context/mod.rs
@@ -76,7 +76,6 @@ impl Drop for Pkcs11Impl {
 #[derive(Clone, Debug)]
 pub struct Pkcs11 {
     pub(crate) impl_: Arc<Pkcs11Impl>,
-    initialized: bool,
 }
 
 impl Pkcs11 {
@@ -99,23 +98,19 @@ impl Pkcs11 {
                     _pkcs11_lib: pkcs11_lib,
                     function_list: *list_ptr,
                 }),
-                initialized: false,
             })
         }
     }
 
     /// Initialize the PKCS11 library
-    pub fn initialize(&mut self, init_args: CInitializeArgs) -> Result<()> {
-        if !self.initialized {
-            initialize(self, init_args)
-        } else {
-            Err(Error::AlreadyInitialized)
-        }
+    pub fn initialize(&self, init_args: CInitializeArgs) -> Result<()> {
+        initialize(self, init_args)
     }
 
     /// Check whether the PKCS11 library has been initialized
+    #[deprecated]
     pub fn is_initialized(&self) -> bool {
-        self.initialized
+        get_library_info(self).is_ok()
     }
 
     /// Finalize the PKCS11 library. Indicates that the application no longer needs to use PKCS11.

--- a/cryptoki/src/error/rv.rs
+++ b/cryptoki/src/error/rv.rs
@@ -131,6 +131,7 @@ impl Rv {
     pub fn into_result(self) -> Result<()> {
         match self {
             Rv::Ok => Ok(()),
+            Rv::Error(RvError::CryptokiAlreadyInitialized) => Err(Error::AlreadyInitialized),
             Rv::Error(rv_error) => Err(Error::Pkcs11(rv_error)),
         }
     }

--- a/cryptoki/tests/common.rs
+++ b/cryptoki/tests/common.rs
@@ -11,12 +11,16 @@ pub static USER_PIN: &str = "fedcba";
 // The default SO pin
 pub static SO_PIN: &str = "abcdef";
 
-pub fn init_pins() -> (Pkcs11, Slot) {
-    let mut pkcs11 = Pkcs11::new(
+pub fn get_pkcs11() -> Pkcs11 {
+    Pkcs11::new(
         env::var("PKCS11_SOFTHSM2_MODULE")
             .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
     )
-    .unwrap();
+    .unwrap()
+}
+
+pub fn init_pins() -> (Pkcs11, Slot) {
+    let pkcs11 = get_pkcs11();
 
     // initialize the library
     pkcs11.initialize(CInitializeArgs::OsThreads).unwrap();


### PR DESCRIPTION
This PR fixes the problem with clone and initialize.

Fixes #151 