### PR TITLE
feat(session): support Signer trait through a Session

### DIFF
--- a/cryptoki/Cargo.toml
+++ b/cryptoki/Cargo.toml
@@ -19,6 +19,7 @@ psa-crypto = { version = "0.9.0", default-features = false, optional = true }
 cryptoki-sys = { path = "../cryptoki-sys", version = "0.1.4" }
 paste = "1.0.6"
 secrecy = "0.8.0"
+signature = { version = "2.1.0", optional = true, features = [ "std" ] }
 
 [dev-dependencies]
 num-traits = "0.2.14"
@@ -27,6 +28,8 @@ serial_test = "0.5.1"
 testresult = "0.2.0"
 
 [features]
+default = [ "signature-traits" ]
 psa-crypto-conversions = ["psa-crypto"]
+signature-traits = ["signature"]
 generate-bindings = ["cryptoki-sys/generate-bindings"]
 serde = ["secrecy/serde"]


### PR DESCRIPTION
`signature` is a widely used "standard" trait, offering high level APIs to manipulate signers and verifier.

This implements a `Signer` trait on a returned `SignatureRequest` through `Session` which is a prepared "signature request" with filled mechanism and key.

This makes it possible to wire cryptoki further with other APIs of the Rust ecosystem.

I made it a default feature for now, let me know if you prefer to remove this.