### PR TITLE
Bump cryptoki to 0.5.0

### DIFF
--- a/cryptoki/Cargo.toml
+++ b/cryptoki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptoki"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Contributors to the Parsec project"]
 edition = '2018'
 description = "Rust-native wrapper around the PKCS #11 API"


### PR DESCRIPTION
Preparing a new release of the crate - it's been a while since the previous one, and we've had [a request](https://github.com/parallaxsecond/rust-cryptoki/pull/132#issuecomment-1662335192).