### PR TITLE
Change lints for the library and allow unknown lints

### DIFF
--- a/cryptoki/src/lib.rs
+++ b/cryptoki/src/lib.rs
@@ -20,6 +20,7 @@
 
 // This list comes from
 // https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
+#![allow(renamed_and_removed_lints, unknown_lints)]
 #![deny(bad_style,
        dead_code,
        improper_ctypes,
@@ -28,8 +29,12 @@
        overflowing_literals,
        path_statements ,
        patterns_in_fns_without_body,
+       private_bounds,
        private_in_public,
+       private_interfaces,
+       renamed_and_removed_lints,
        unconditional_recursion,
+       unnameable_types,
        unused,
        unused_allocation,
        unused_comparisons,


### PR DESCRIPTION
The nightly test "Execute cargo udeps" complains with a warning:

warning: lint `private_in_public` has been removed: replaced with another group of lints, see
RFC <https://rust-lang.github.io/rfcs/2145-type-privacy.html> for more information.

 * Keep the private_in_public lint for the MSRV
 * Add the replacement lints for builds with newer rustc versions.
 * Add #![allow(unknown_lints)] to make both of the last items compatible with each other