### PR TITLE
nightly: Add the loongaarch64-unkown-linux-gnu target

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,6 +58,7 @@ jobs:
           rustup target add x86_64-apple-darwin &&
           rustup target add aarch64-apple-darwin &&
           rustup target add x86_64-unknown-freebsd
+          rustup target add loongarch64-unknown-linux-gnu
 
       - name: Test script
         env:


### PR DESCRIPTION
Fixes nightly issues.
Please refer to https://github.com/parallaxsecond/rust-cryptoki/actions/runs/6923840384
