### PR TITLE
Fix clippy warnings introduced with rust 1.75

### DIFF
--- a/cryptoki/src/context/session_management.rs
+++ b/cryptoki/src/context/session_management.rs
@@ -8,7 +8,6 @@ use crate::context::Pkcs11;
 use crate::error::{Result, Rv};
 use crate::session::Session;
 use crate::slot::Slot;
-use std::convert::TryInto;
 
 impl Pkcs11 {
     #[inline(always)]
@@ -22,7 +21,7 @@ impl Pkcs11 {
         };
         unsafe {
             Rv::from(get_pkcs11!(self, C_OpenSession)(
-                slot_id.try_into()?,
+                slot_id.into(),
                 flags,
                 // TODO: abstract those types or create new functions for callbacks
                 std::ptr::null_mut(),

--- a/cryptoki/src/context/slot_token_management.rs
+++ b/cryptoki/src/context/slot_token_management.rs
@@ -87,7 +87,7 @@ impl Pkcs11 {
         let label = label_from_str(label);
         unsafe {
             Rv::from(get_pkcs11!(self, C_InitToken)(
-                slot.try_into()?,
+                slot.into(),
                 pin.expose_secret().as_ptr() as *mut u8,
                 pin.expose_secret().len().try_into()?,
                 label.as_ptr() as *mut u8,
@@ -101,7 +101,7 @@ impl Pkcs11 {
         unsafe {
             let mut slot_info = CK_SLOT_INFO::default();
             Rv::from(get_pkcs11!(self, C_GetSlotInfo)(
-                slot.try_into()?,
+                slot.into(),
                 &mut slot_info,
             ))
             .into_result()?;
@@ -114,7 +114,7 @@ impl Pkcs11 {
         unsafe {
             let mut token_info = CK_TOKEN_INFO::default();
             Rv::from(get_pkcs11!(self, C_GetTokenInfo)(
-                slot.try_into()?,
+                slot.into(),
                 &mut token_info,
             ))
             .into_result()?;
@@ -128,7 +128,7 @@ impl Pkcs11 {
 
         unsafe {
             Rv::from(get_pkcs11!(self, C_GetMechanismList)(
-                slot.try_into()?,
+                slot.into(),
                 std::ptr::null_mut(),
                 &mut mechanism_count,
             ))
@@ -139,7 +139,7 @@ impl Pkcs11 {
 
         unsafe {
             Rv::from(get_pkcs11!(self, C_GetMechanismList)(
-                slot.try_into()?,
+                slot.into(),
                 mechanisms.as_mut_ptr(),
                 &mut mechanism_count,
             ))
@@ -160,7 +160,7 @@ impl Pkcs11 {
         unsafe {
             let mut mechanism_info = CK_MECHANISM_INFO::default();
             Rv::from(get_pkcs11!(self, C_GetMechanismInfo)(
-                slot.try_into()?,
+                slot.into(),
                 type_.into(),
                 &mut mechanism_info,
             ))

--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -818,10 +818,10 @@ impl TryFrom<CK_ATTRIBUTE> for Attribute {
             }
             // CK_ULONG
             AttributeType::ModulusBits => Ok(Attribute::ModulusBits(
-                CK_ULONG::from_ne_bytes(val.try_into()?).try_into()?,
+                CK_ULONG::from_ne_bytes(val.try_into()?).into(),
             )),
             AttributeType::ValueLen => Ok(Attribute::ValueLen(
-                CK_ULONG::from_ne_bytes(val.try_into()?).try_into()?,
+                CK_ULONG::from_ne_bytes(val.try_into()?).into(),
             )),
             // Vec<u8>
             AttributeType::AcIssuer => Ok(Attribute::AcIssuer(val.to_vec())),

--- a/cryptoki/src/session/random.rs
+++ b/cryptoki/src/session/random.rs
@@ -33,7 +33,7 @@ impl Session {
             Rv::from(get_pkcs11!(self.client(), C_GenerateRandom)(
                 self.handle(),
                 result.as_mut_ptr(),
-                random_len.try_into()?,
+                random_len.into(),
             ))
             .into_result()?;
         }

--- a/cryptoki/src/slot/mod.rs
+++ b/cryptoki/src/slot/mod.rs
@@ -64,7 +64,7 @@ impl TryFrom<u32> for Slot {
 
     fn try_from(slot_id: u32) -> Result<Self> {
         Ok(Self {
-            slot_id: slot_id.try_into()?,
+            slot_id: slot_id.into(),
         })
     }
 }


### PR DESCRIPTION
This would raise errors in CI after the bump to rustc 1.75