### PR TITLE
Add support for `CARGO_TARGET_DIR` in `regenerate_bindings.sh`

### DIFF
--- a/cryptoki-sys/regenerate_bindings.sh
+++ b/cryptoki-sys/regenerate_bindings.sh
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -xeuf -o pipefail
-
-find ../target/ -name "pkcs11_bindings.rs" -delete
+TARGET_DIR=${CARGO_TARGET_DIR:-../target}
+find "$TARGET_DIR" -name "pkcs11_bindings.rs" -delete
 MAKE_GENERIC_BINDINGS=1 cargo build --features generate-bindings
-find ../target/ -name "pkcs11_bindings.rs" | xargs -I '{}' cp '{}' src/bindings/generic.rs
+find "$TARGET_DIR" -name "pkcs11_bindings.rs" | xargs -I '{}' cp '{}' src/bindings/generic.rs
 
 targets="aarch64-unknown-linux-gnu arm-unknown-linux-gnueabi loongarch64-unknown-linux-gnu x86_64-pc-windows-msvc i686-unknown-linux-gnu powerpc64-unknown-linux-gnu x86_64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin x86_64-unknown-freebsd"
 TARGET_INSTALLED=
@@ -21,7 +21,7 @@ for target in $targets; do
     fi
 
     cargo build --target "$target" --features generate-bindings
-    find ../target/"$target"/ -name "pkcs11_bindings.rs" | xargs -I '{}' cp '{}' src/bindings/"$target".rs
+    find "$TARGET_DIR"/"$target"/ -name "pkcs11_bindings.rs" | xargs -I '{}' cp '{}' src/bindings/"$target".rs
 
     if [ "$TARGET_INSTALLED" == "$target" ]; then
         rustup target remove "$target"


### PR DESCRIPTION
The script to regenerate bindings hardcoded `../target` path. This did not work if the user customized the target directory location through the `CARGO_TARGET_DIR` environment variable.

Fix the issue by first reading the variable and default to `../target` if it is unset.