### PR TITLE
Expose PkcsOaepParams' message digest algorithm

### DIFF
--- a/cryptoki/src/mechanism/rsa.rs
+++ b/cryptoki/src/mechanism/rsa.rs
@@ -173,6 +173,11 @@ impl<'a> PkcsOaepParams<'a> {
             _marker: PhantomData,
         }
     }
+
+    /// Get the message digest algorithm for the `PkcsOaepParams`.
+    pub fn hash_alg(&self) -> MechanismType {
+        self.hash_alg
+    }
 }
 
 impl<'a> From<PkcsOaepParams<'a>> for Mechanism<'a> {

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -1046,6 +1046,7 @@ fn rsa_pkcs_oaep_empty() -> TestResult {
         PkcsMgfType::MGF1_SHA1,
         PkcsOaepSource::empty(),
     );
+    assert_eq!(MechanismType::SHA1, oaep.hash_alg());
     let encrypt_mechanism: Mechanism = Mechanism::RsaPkcsOaep(oaep);
     let encrypted_data = session.encrypt(&encrypt_mechanism, pubkey, b"Hello")?;
 


### PR DESCRIPTION
 * Create the hash_alg() method that exposes the corresponding MechanismType
 * Test this in one of the PkcsOaepParams tests

