### PR TITLE
Session.find_objects(): implement fewer calls to C_FindObjects()

### DIFF
--- a/cryptoki/src/session/object_management.rs
+++ b/cryptoki/src/session/object_management.rs
@@ -44,6 +44,13 @@ impl Session {
         while object_count > 0 {
             objects.extend_from_slice(&object_handles[..object_count.try_into()?]);
 
+            // If the returned slice is not full, there are no pending object handles to be returned.
+            // In which case, exit loop.
+            // This avoids, in many situations, an unecessary API call with 0 object handles returned.
+            if (object_count as usize) < MAX_OBJECT_COUNT {
+                break;
+            }
+
             unsafe {
                 Rv::from(get_pkcs11!(self.client(), C_FindObjects)(
                     self.handle(),

--- a/cryptoki/src/session/object_management.rs
+++ b/cryptoki/src/session/object_management.rs
@@ -46,7 +46,7 @@ impl Session {
 
             // If the returned slice is not full, there are no pending object handles to be returned.
             // In which case, exit loop.
-            // This avoids, in many situations, an unecessary API call with 0 object handles returned.
+            // This avoids, in many situations, an unnecessary API call with 0 object handles returned.
             if (object_count as usize) < MAX_OBJECT_COUNT {
                 break;
             }

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -332,7 +332,7 @@ fn session_find_objects() {
             Attribute::Token(true),
             Attribute::Encrypt(true),
             Attribute::Label(format!("key_{}", i).as_bytes().to_vec()),
-            Attribute::Id("12345678".as_bytes().to_vec()),          // reusing the same CKA_ID
+            Attribute::Id("12345678".as_bytes().to_vec()), // reusing the same CKA_ID
         ];
 
         // generate a secret key
@@ -340,7 +340,6 @@ fn session_find_objects() {
             .generate_key(&Mechanism::Des3KeyGen, &key_template)
             .unwrap();
     });
-
 
     // retrieve the keys by searching for them
     let key_search_template = vec![
@@ -363,7 +362,6 @@ fn session_find_objects() {
     session.destroy_object(found_keys.pop().unwrap()).unwrap();
     let found_keys = session.find_objects(&key_search_template).unwrap();
     assert_eq!(found_keys.len(), 9);
-
 }
 
 #[test]


### PR DESCRIPTION
This PR contains code that optimizes `Session.find_objects()`. It essentially quit the loop as soon as less than `MAX_OBJECT_COUNT` have been returned by `C_FindObjects()`. 

It typically results in calling one less time the underlying API `C_FindObjects()`.

Testing code included.
