### PR TITLE
Implement Session.copy_object()

### DIFF
--- a/cryptoki/src/session/object_management.rs
+++ b/cryptoki/src/session/object_management.rs
@@ -97,12 +97,14 @@ impl Session {
     }
 
     /// Copy an object
+    ///
     /// A template can be provided to change some attributes of the new object, when allowed.
     ///
     /// # Arguments
     ///
     /// * `object` - The [ObjectHandle] used to reference the object to copy
-    /// * `template` - a reference to a slice of attributes
+    /// * `template` - new values for any attributes of the object that can ordinarily be modified
+    ///   check out [PKCS#11 documentation](https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/cs01/pkcs11-spec-v3.1-cs01.html#_Toc111203284) for details
     ///
     /// # Returns
     ///
@@ -124,7 +126,7 @@ impl Session {
                 template.len().try_into()?,
                 &mut object_handle as CK_OBJECT_HANDLE_PTR,
             ))
-            .into_result(Function::CreateObject)?;
+            .into_result(Function::CopyObject)?;
         }
 
         Ok(ObjectHandle::new(object_handle))

--- a/cryptoki/src/session/object_management.rs
+++ b/cryptoki/src/session/object_management.rs
@@ -97,24 +97,19 @@ impl Session {
     }
 
     /// Copy an object
-    /// A optional template can be provided to change some attributes of the new object, when allowed.
+    /// A template can be provided to change some attributes of the new object, when allowed.
     ///
     /// # Arguments
     ///
     /// * `object` - The [ObjectHandle] used to reference the object to copy
-    /// * `template` - an optional reference to a slice of attributes, in the form of `Some(&[Attribute])`, 
-    ///    or set to `None`` if not needed.
+    /// * `template` - a reference to a slice of attributes
     ///
     /// # Returns
     ///
     /// This function will return a new [ObjectHandle] that references the newly created object.
     ///
-    pub fn copy_object(&self, object: ObjectHandle, template: Option<&[Attribute]>) -> Result<ObjectHandle> {
-        let mut template: Vec<CK_ATTRIBUTE> = match template {
-            Some(template) => template.iter().map(|attr| attr.into()).collect(),
-            None => Vec::new(),
-        };
-
+    pub fn copy_object(&self, object: ObjectHandle, template: &[Attribute]) -> Result<ObjectHandle> {
+        let mut template: Vec<CK_ATTRIBUTE> = template.iter().map(|attr| attr.into()).collect();
         let mut object_handle = 0;
 
         unsafe {

--- a/cryptoki/src/session/object_management.rs
+++ b/cryptoki/src/session/object_management.rs
@@ -108,7 +108,11 @@ impl Session {
     ///
     /// This function will return a new [ObjectHandle] that references the newly created object.
     ///
-    pub fn copy_object(&self, object: ObjectHandle, template: &[Attribute]) -> Result<ObjectHandle> {
+    pub fn copy_object(
+        &self,
+        object: ObjectHandle,
+        template: &[Attribute],
+    ) -> Result<ObjectHandle> {
         let mut template: Vec<CK_ATTRIBUTE> = template.iter().map(|attr| attr.into()).collect();
         let mut object_handle = 0;
 

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -853,13 +853,9 @@ fn session_copy_object() -> TestResult {
         Attribute::Label("original".as_bytes().to_vec()),
     ];
 
-    let copy_template = vec![
-        Attribute::Label("copy".as_bytes().to_vec()),
-    ];
+    let copy_template = vec![Attribute::Label("copy".as_bytes().to_vec())];
 
-    let insecure_copy_template = vec![
-        Attribute::Extractable(true),
-    ];
+    let insecure_copy_template = vec![Attribute::Extractable(true)];
 
     let (pkcs11, slot) = init_pins();
 
@@ -881,7 +877,9 @@ fn session_copy_object() -> TestResult {
     rw_session.destroy_object(copy)?;
 
     // try the copy with the insecure template. It should fail. Returning CKR_OK is considered a failure.
-    rw_session.copy_object(object, &insecure_copy_template).unwrap_err();
+    rw_session
+        .copy_object(object, &insecure_copy_template)
+        .unwrap_err();
 
     // delete keys
     rw_session.destroy_object(object)?;
@@ -889,7 +887,6 @@ fn session_copy_object() -> TestResult {
 
     Ok(())
 }
-
 
 #[test]
 #[serial]

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -873,15 +873,15 @@ fn session_copy_object() -> TestResult {
     let object = rw_session.generate_key(&Mechanism::AesKeyGen, &aes128_template)?;
 
     // copy the object without a template
-    let copy = rw_session.copy_object(object, None)?;
+    let copy = rw_session.copy_object(object, &[])?;
     rw_session.destroy_object(copy)?;
 
     // copy the object with a template
-    let copy = rw_session.copy_object(object, Some(&copy_template))?;
+    let copy = rw_session.copy_object(object, &copy_template)?;
     rw_session.destroy_object(copy)?;
 
     // try the copy with the insecure template. It should fail. Returning CKR_OK is considered a failure.
-    rw_session.copy_object(object, Some(&insecure_copy_template)).unwrap_err();
+    rw_session.copy_object(object, &insecure_copy_template).unwrap_err();
 
     // delete keys
     rw_session.destroy_object(object)?;


### PR DESCRIPTION
This PR implements `C_CopyObject()`. It takes a template as an optional argument (i.e. `Option<&[Attribute]>`).

The PR comes along with rustdoc and dedicated test case.
