### PR TITLE
Support vendor extensions for CK_USER_TYPE

### DIFF
--- a/cryptoki/src/session/mod.rs
+++ b/cryptoki/src/session/mod.rs
@@ -90,6 +90,8 @@ pub enum UserType {
     User,
     /// Context Specific
     ContextSpecific,
+    /// Vendor extension
+    VendorExtension(u32)
 }
 
 impl From<UserType> for CK_USER_TYPE {
@@ -98,6 +100,7 @@ impl From<UserType> for CK_USER_TYPE {
             UserType::So => CKU_SO,
             UserType::User => CKU_USER,
             UserType::ContextSpecific => CKU_CONTEXT_SPECIFIC,
+            UserType::VendorExtension(n) => n as CK_USER_TYPE
         }
     }
 }

--- a/cryptoki/src/session/mod.rs
+++ b/cryptoki/src/session/mod.rs
@@ -91,7 +91,7 @@ pub enum UserType {
     /// Context Specific
     ContextSpecific,
     /// Vendor extension
-    VendorExtension(u32)
+    VendorExtension(u32),
 }
 
 impl From<UserType> for CK_USER_TYPE {
@@ -100,7 +100,7 @@ impl From<UserType> for CK_USER_TYPE {
             UserType::So => CKU_SO,
             UserType::User => CKU_USER,
             UserType::ContextSpecific => CKU_CONTEXT_SPECIFIC,
-            UserType::VendorExtension(n) => n as CK_USER_TYPE
+            UserType::VendorExtension(n) => n as CK_USER_TYPE,
         }
     }
 }

--- a/cryptoki/src/session/mod.rs
+++ b/cryptoki/src/session/mod.rs
@@ -95,12 +95,14 @@ pub enum UserType {
 }
 
 impl From<UserType> for CK_USER_TYPE {
+    // Mask lint for n.into() on 32-bit systems.
+    #![allow(clippy::useless_conversion)]
     fn from(user_type: UserType) -> CK_USER_TYPE {
         match user_type {
             UserType::So => CKU_SO,
             UserType::User => CKU_USER,
             UserType::ContextSpecific => CKU_CONTEXT_SPECIFIC,
-            UserType::VendorExtension(n) => n as CK_USER_TYPE,
+            UserType::VendorExtension(n) => n.into(),
         }
     }
 }


### PR DESCRIPTION
Some HSM vendors have more user types than the standard CKU_SO and CKU_USER. For example a Thales Luna uses the value 0x80000001 to represent the unprivileged Crypto User.
