### PR TITLE
fix compilation issues with Rust 1.79

### DIFF
--- a/cryptoki/src/mechanism/mod.rs
+++ b/cryptoki/src/mechanism/mod.rs
@@ -16,6 +16,7 @@ use std::ffi::c_void;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::ptr::null_mut;
+use std::mem::size_of;
 
 use crate::mechanism::rsa::PkcsOaepParams;
 pub use mechanism_info::MechanismInfo;

--- a/cryptoki/src/mechanism/mod.rs
+++ b/cryptoki/src/mechanism/mod.rs
@@ -14,9 +14,9 @@ use log::error;
 use std::convert::{TryFrom, TryInto};
 use std::ffi::c_void;
 use std::fmt::Formatter;
+use std::mem::size_of;
 use std::ops::Deref;
 use std::ptr::null_mut;
-use std::mem::size_of;
 
 use crate::mechanism::rsa::PkcsOaepParams;
 pub use mechanism_info::MechanismInfo;

--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -12,6 +12,7 @@ use std::convert::TryInto;
 use std::ffi::c_void;
 use std::fmt::Formatter;
 use std::ops::Deref;
+use std::mem::size_of;
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 #[non_exhaustive]

--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -11,8 +11,8 @@ use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::ffi::c_void;
 use std::fmt::Formatter;
-use std::ops::Deref;
 use std::mem::size_of;
+use std::ops::Deref;
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 #[non_exhaustive]


### PR DESCRIPTION
This PR comes in support to fix issue #221. It has been tested against various versions of Rust: 1.79, 1.75, 1.66 and 1.80.

It just adds two `use std::mem::size_of` statements.