### PR TITLE
feat: add HKDF mechanisms

### DIFF
--- a/cryptoki/src/mechanism/hkdf.rs
+++ b/cryptoki/src/mechanism/hkdf.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 //! Mechanisms of hash-based key derive function (HKDF)
 //! See: <https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.0/os/pkcs11-curr-v3.0-os.html#_Toc30061597>
 
@@ -9,8 +11,8 @@ use crate::object::ObjectHandle;
 
 use super::MechanismType;
 
-#[derive(Debug, Clone, Copy)]
 /// The salt for the extract stage.
+#[derive(Debug, Clone, Copy)]
 pub enum HkdfSalt<'a> {
     /// CKF_HKDF_SALT_NULL no salt is supplied.
     Null,
@@ -62,16 +64,17 @@ impl<'a> HkdfParams<'a> {
                     HkdfSalt::Data(_) => CKF_HKDF_SALT_DATA,
                     HkdfSalt::Key(_) => CKF_HKDF_SALT_KEY,
                 },
-                pSalt: match salt {
-                    HkdfSalt::Data(data) => data.as_ptr() as *mut _,
-                    _ => null_mut(),
+                pSalt: if let HkdfSalt::Data(data) = salt {
+                    data.as_ptr() as *mut _
+                } else {
+                    null_mut()
                 },
-                ulSaltLen: match salt {
-                    HkdfSalt::Data(data) => data
-                        .len()
+                ulSaltLen: if let HkdfSalt::Data(data) = salt {
+                    data.len()
                         .try_into()
-                        .expect("salt length does not fit in CK_ULONG"),
-                    _ => 0,
+                        .expect("salt length does not fit in CK_ULONG")
+                } else {
+                    0
                 },
                 hSaltKey: match salt {
                     HkdfSalt::Key(key) => key.handle(),

--- a/cryptoki/src/mechanism/hkdf.rs
+++ b/cryptoki/src/mechanism/hkdf.rs
@@ -1,0 +1,116 @@
+//! Mechanisms of hash-based key derive function (HKDF)
+//! See: <https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.0/os/pkcs11-curr-v3.0-os.html#_Toc30061597>
+
+use std::{convert::TryInto, marker::PhantomData, ptr::null_mut, slice};
+
+use cryptoki_sys::{CKF_HKDF_SALT_DATA, CKF_HKDF_SALT_KEY, CKF_HKDF_SALT_NULL};
+
+use crate::object::ObjectHandle;
+
+use super::MechanismType;
+
+#[derive(Debug, Clone, Copy)]
+/// The salt for the extract stage.
+pub enum HkdfSalt<'a> {
+    /// CKF_HKDF_SALT_NULL no salt is supplied.
+    Null,
+    /// CKF_HKDF_SALT_DATA salt is supplied as a data in pSalt with length ulSaltLen.
+    Data(&'a [u8]),
+    /// CKF_HKDF_SALT_KEY salt is supplied as a key in hSaltKey
+    Key(ObjectHandle),
+}
+
+/// HKDF parameters.
+///
+/// This structure wraps a `CK_HKDF_PARAMS` structure.
+#[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
+pub struct HkdfParams<'a> {
+    inner: cryptoki_sys::CK_HKDF_PARAMS,
+    /// Marker type to ensure we don't outlive the data
+    _marker: PhantomData<&'a [u8]>,
+}
+
+impl<'a> HkdfParams<'a> {
+    /// Construct parameters for hash-based key derive function (HKDF).
+    ///
+    /// # Arguments
+    ///
+    /// * `extract` - Whether to execute the extract portion of HKDF.
+    ///
+    /// * `expand` - Whether to execute the expand portion of HKDF.
+    ///
+    /// * `prf_hash_mechanism` - The base hash used for the HMAC in the underlying HKDF operation
+    ///
+    /// * `salt` - The salt for the extract stage.
+    ///
+    /// * `info` - The info string for the expand stage.
+    pub fn new(
+        extract: bool,
+        expand: bool,
+        prf_hash_mechanism: MechanismType,
+        salt: HkdfSalt,
+        info: &'a [u8],
+    ) -> Self {
+        Self {
+            inner: cryptoki_sys::CK_HKDF_PARAMS {
+                bExtract: extract as u8,
+                bExpand: expand as u8,
+                prfHashMechanism: *prf_hash_mechanism,
+                ulSaltType: match salt {
+                    HkdfSalt::Null => CKF_HKDF_SALT_NULL,
+                    HkdfSalt::Data(_) => CKF_HKDF_SALT_DATA,
+                    HkdfSalt::Key(_) => CKF_HKDF_SALT_KEY,
+                },
+                pSalt: match salt {
+                    HkdfSalt::Data(data) => data.as_ptr() as *mut _,
+                    _ => null_mut(),
+                },
+                ulSaltLen: match salt {
+                    HkdfSalt::Data(data) => data
+                        .len()
+                        .try_into()
+                        .expect("salt length does not fit in CK_ULONG"),
+                    _ => 0,
+                },
+                hSaltKey: match salt {
+                    HkdfSalt::Key(key) => key.handle(),
+                    _ => 0,
+                },
+                pInfo: info.as_ptr() as *mut _,
+                ulInfoLen: info
+                    .len()
+                    .try_into()
+                    .expect("info length does not fit in CK_ULONG"),
+            },
+            _marker: PhantomData,
+        }
+    }
+
+    /// Whether to execute the extract portion of HKDF.
+    pub fn extract(&self) -> bool {
+        self.inner.bExtract != 0
+    }
+
+    /// Whether to execute the expand portion of HKDF.
+    pub fn expand(&self) -> bool {
+        self.inner.bExpand != 0
+    }
+
+    /// The salt for the extract stage.
+    pub fn salt(&self) -> HkdfSalt<'a> {
+        match self.inner.ulSaltType {
+            CKF_HKDF_SALT_NULL => HkdfSalt::Null,
+            CKF_HKDF_SALT_DATA => HkdfSalt::Data(unsafe {
+                slice::from_raw_parts(self.inner.pSalt, self.inner.ulSaltLen as _)
+            }),
+            CKF_HKDF_SALT_KEY => HkdfSalt::Key(ObjectHandle::new(self.inner.hSaltKey)),
+            _ => unreachable!(),
+        }
+    }
+
+    /// The info string for the expand stage.
+    pub fn info(&self) -> &'a [u8] {
+        unsafe { slice::from_raw_parts(self.inner.pInfo, self.inner.ulInfoLen as _) }
+    }
+}

--- a/cryptoki/src/mechanism/hkdf.rs
+++ b/cryptoki/src/mechanism/hkdf.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Contributors to the Parsec project.
+// Copyright 2024 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 //! Mechanisms of hash-based key derive function (HKDF)
 //! See: <https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.0/os/pkcs11-curr-v3.0-os.html#_Toc30061597>

--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -1192,6 +1192,9 @@ impl KeyType {
         val: CKK_EC_MONTGOMERY,
     };
 
+    /// HKDF key
+    pub const HKDF: KeyType = KeyType { val: CKK_HKDF };
+
     fn stringify(key_type: CK_KEY_TYPE) -> String {
         match key_type {
             CKK_RSA => String::from(stringify!(CKK_RSA)),
@@ -1236,6 +1239,8 @@ impl KeyType {
             CKK_GOSTR3411 => String::from(stringify!(CKK_GOSTR3411)),
             CKK_GOST28147 => String::from(stringify!(CKK_GOST28147)),
             CKK_EC_EDWARDS => String::from(stringify!(CKK_EC_EDWARDS)),
+            CKK_EC_MONTGOMERY => String::from(stringify!(CKK_EC_MONTGOMERY)),
+            CKK_HKDF => String::from(stringify!(CKK_HKDF)),
             _ => format!("unknown ({key_type:08x})"),
         }
     }
@@ -1309,6 +1314,7 @@ impl TryFrom<CK_KEY_TYPE> for KeyType {
             CKK_GOST28147 => Ok(KeyType::GOST28147),
             CKK_EC_EDWARDS => Ok(KeyType::EC_EDWARDS),
             CKK_EC_MONTGOMERY => Ok(KeyType::EC_MONTGOMERY),
+            CKK_HKDF => Ok(KeyType::HKDF),
             _ => {
                 error!("Key type {} is not supported.", key_type);
                 Err(Error::NotSupported)


### PR DESCRIPTION
Add HKDF mechanisms to `cryptoki` and `cryptoki-sys`. The mechanisms were defined in [PKCS#11 v3.0](https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.0/os/pkcs11-curr-v3.0-os.html#_Toc30061597).

I found that SoftHSM doesn't support such mechanisms so I couldn't write any unit test. But I did run some `CKM_HKDF_DERIVE` tests against our own HSM and it works.