### PR TITLE
feat: support vendor defined mechanisms

### DIFF
--- a/cryptoki/src/mechanism/mod.rs
+++ b/cryptoki/src/mechanism/mod.rs
@@ -313,6 +313,8 @@ impl MechanismType {
     ///
     /// It maps to
     /// ```rust
+    /// use cryptoki::mechanism::MechanismType;
+    ///
     /// pub const CKM_SOME_CUSTOM_MECH: MechanismType =
     ///     MechanismType::new_vendor_defined(0x00000001);
     /// ```

--- a/cryptoki/src/mechanism/mod.rs
+++ b/cryptoki/src/mechanism/mod.rs
@@ -316,7 +316,7 @@ impl MechanismType {
     /// pub const CKM_SOME_CUSTOM_MECH: MechanismType =
     ///     MechanismType::new_vendor_defined(0x00000001);
     /// ```
-    pub const fn new_vendor_defined(adding: u64) -> MechanismType {
+    pub const fn new_vendor_defined(adding: CK_ULONG) -> MechanismType {
         MechanismType {
             val: CKM_VENDOR_DEFINED | adding,
         }

--- a/cryptoki/src/mechanism/mod.rs
+++ b/cryptoki/src/mechanism/mod.rs
@@ -304,23 +304,24 @@ impl MechanismType {
     ///
     /// # Arguments
     ///
-    /// * `adding` - The adding based on `CKM_VENDOR_DEFINED`
+    /// * `val` - The value of vendor defined mechanism
     ///
-    /// Usually vendors defines custom mechanism like this:
-    /// ```c
-    /// #define CKM_SOME_CUSTOM_MECH (CKM_VENDOR_DEFINED | 0x00000001UL)
-    /// ```
+    /// # Errors
     ///
-    /// It maps to
+    /// If `val` is less then `CKM_VENDOR_DEFINED`, a `Error::InvalidValue` will be returned
+    ///
+    /// # Examples
     /// ```rust
-    /// use cryptoki::mechanism::MechanismType;
+    /// use cryptoki::mechanism::{vendor_defined::CKM_VENDOR_DEFINED, MechanismType};
     ///
-    /// pub const CKM_SOME_CUSTOM_MECH: MechanismType =
-    ///     MechanismType::new_vendor_defined(0x00000001);
+    /// let some_custom_mech: MechanismType =
+    ///     MechanismType::new_vendor_defined(CKM_VENDOR_DEFINED | 0x00000001).unwrap();
     /// ```
-    pub const fn new_vendor_defined(adding: CK_ULONG) -> MechanismType {
-        MechanismType {
-            val: CKM_VENDOR_DEFINED | adding,
+    pub fn new_vendor_defined(val: CK_MECHANISM_TYPE) -> crate::error::Result<MechanismType> {
+        if val < CKM_VENDOR_DEFINED {
+            Err(Error::InvalidValue)
+        } else {
+            Ok(MechanismType { val })
         }
     }
 

--- a/cryptoki/src/mechanism/vendor_defined.rs
+++ b/cryptoki/src/mechanism/vendor_defined.rs
@@ -6,6 +6,7 @@
 
 use std::{marker::PhantomData, ptr::null_mut};
 
+pub use cryptoki_sys::CKM_VENDOR_DEFINED;
 use cryptoki_sys::CK_MECHANISM;
 
 use super::{make_mechanism, MechanismType};

--- a/cryptoki/src/mechanism/vendor_defined.rs
+++ b/cryptoki/src/mechanism/vendor_defined.rs
@@ -1,0 +1,36 @@
+// Copyright 2024 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! Mechanism types are defined with the objects and mechanism descriptions that use them.
+//! Vendor defined values for this type may also be specified.
+//! See: <https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/os/pkcs11-base-v3.0-os.html#_Toc29976545>
+
+use std::{marker::PhantomData, ptr::null_mut};
+
+use cryptoki_sys::CK_MECHANISM;
+
+use super::{make_mechanism, MechanismType};
+
+/// Vendor defined mechanism.
+#[derive(Debug, Clone, Copy)]
+pub struct VendorDefinedMechanism<'a> {
+    pub(crate) inner: CK_MECHANISM,
+    /// Marker type to ensure we don't outlive the data
+    _marker: PhantomData<&'a [u8]>,
+}
+
+impl<'a> VendorDefinedMechanism<'a> {
+    /// Create a new vendor defined mechanism.
+    pub fn new<T>(mechanism_type: MechanismType, params: Option<&'a T>) -> Self {
+        Self {
+            inner: match params {
+                Some(params) => make_mechanism(mechanism_type.val, params),
+                None => CK_MECHANISM {
+                    mechanism: mechanism_type.val,
+                    pParameter: null_mut(),
+                    ulParameterLen: 0,
+                },
+            },
+            _marker: PhantomData,
+        }
+    }
+}


### PR DESCRIPTION
Add support for vendor defined mechanisms.

In order to avoid issues mentioned in #105, the parameters are pre-serialized in `VendorDefinedMechanism::new`, so we don't need to introduce generic to `Mechanism` or pay extra cost for dynamic dispatching.
It's also guaranteed that the new mechanism value is greater or equal to `CKM_VENDOR_DEFINED`.

It seems to be working fine with AWS CloudHSM's custom `CKM_SP800_108_COUNTER_KDF`.

