### PR TITLE
Define CKD_SHA256_KDF transformation

### DIFF
--- a/cryptoki/src/mechanism/elliptic_curve.rs
+++ b/cryptoki/src/mechanism/elliptic_curve.rs
@@ -93,6 +93,17 @@ impl EcKdf<'_> {
         }
     }
 
+    /// The key derivation function based on sha256 as defined in the ANSI X9.63 standard. The
+    /// derived key is produced by concatenating hashes of the shared
+    /// value followed by 00000001, 00000002, etc. until we find
+    /// enough bytes to fill the `CKA_VALUE_LEN` of the derived key.
+    pub fn sha256() -> Self {
+        Self {
+            kdf_type: CKD_SHA256_KDF,
+            shared_data: None,
+        }
+    }
+
     // The intention here is to be able to support other methods with
     // shared data, without it being a breaking change, by just adding
     // additional constructors here.


### PR DESCRIPTION
Originally done by @freedge at https://github.com/parallaxsecond/rust-cryptoki/pull/213

Define CKD_SHA256_KDF transformation to be used with CKM_ECDH1_DERIVE.

Some HSM with FIPS restriction will refuse to derive keys with CKD_NULL. CKD_SHA256_KDF will do fine though.

Unfortunately this is not implemented on softHSM
(https://github.com/opendnssec/SoftHSMv2/pull/599) so I provide no test. This was tested fine against Thales DPOD.

Fix #92 