### PR TITLE
attribute extension defining Unhanled attribute type and EC Kdf improvements

### DIFF
--- a/cryptoki/src/mechanism/elliptic_curve.rs
+++ b/cryptoki/src/mechanism/elliptic_curve.rs
@@ -19,17 +19,17 @@ use std::ptr;
 #[repr(C)]
 pub struct Ecdh1DeriveParams<'a> {
     /// Key derivation function
-    kdf: CK_EC_KDF_TYPE,
+    pub kdf: CK_EC_KDF_TYPE,
     /// Length of the optional shared data used by some of the key
     /// derivation functions
-    shared_data_len: Ulong,
+    pub shared_data_len: Ulong,
     /// Address of the optional data or `std::ptr::null()` of there is
     /// no shared data
-    shared_data: *const u8,
+    pub shared_data: *const u8,
     /// Length of the other party's public key
-    public_data_len: Ulong,
+    pub public_data_len: Ulong,
     /// Pointer to the other party public key
-    public_data: *const u8,
+    pub public_data: *const u8,
     /// Marker type to ensure we don't outlive shared and public data
     _marker: PhantomData<&'a [u8]>,
 }
@@ -82,7 +82,15 @@ pub struct EcKdf<'a> {
     shared_data: Option<&'a [u8]>,
 }
 
-impl EcKdf<'_> {
+impl<'a> EcKdf<'a> {
+    /// Define KDF_TYPE and shared_data
+    pub fn new(kdf_type: CK_EC_KDF_TYPE, shared_data: Option<&'a [u8]>) -> Self {
+        Self {
+            kdf_type,
+            shared_data,
+        }
+    }
+
     /// The null transformation. The derived key value is produced by
     /// taking bytes from the left of the agreed value. The new key
     /// size is limited to the size of the agreed value.

--- a/cryptoki/src/mechanism/rsa.rs
+++ b/cryptoki/src/mechanism/rsa.rs
@@ -137,15 +137,15 @@ pub struct PkcsPssParams {
 pub struct PkcsOaepParams<'a> {
     /// mechanism ID of the message digest algorithm used to calculate the digest of the encoding
     /// parameter
-    hash_alg: MechanismType,
+    pub hash_alg: MechanismType,
     /// mask generation function to use on the encoded block
-    mgf: PkcsMgfType,
+    pub mgf: PkcsMgfType,
     /// source of the encoding parameter
-    source: CK_RSA_PKCS_OAEP_SOURCE_TYPE,
+    pub source: CK_RSA_PKCS_OAEP_SOURCE_TYPE,
     /// data used as the input for the encoding parameter source
-    source_data: *const c_void,
+    pub source_data: *const c_void,
     /// length of the encoding parameter source input
-    source_data_len: Ulong,
+    pub source_data_len: Ulong,
     /// marker type to ensure we don't outlive the source_data
     _marker: PhantomData<&'a [u8]>,
 }


### PR DESCRIPTION
For undefined attribute types in PKCS#11 spec, I defined Unhandled attribute type to get attribute type value and data value as Vec<u8> type. I also change visibility of the struct variables to edit outside of the module. ECKdf struct edited for defining KDF type and shared value.