### PR TITLE
Add support for PKCS#11 3.0

### DIFF
--- a/.github/actions/ci_script/action.yml
+++ b/.github/actions/ci_script/action.yml
@@ -30,7 +30,7 @@ runs:
 
     - name: Test script
       env:
-        PKCS11_SOFTHSM2_MODULE: /usr/lib/softhsm/libsofthsm2.so
+        TEST_PKCS11_MODULE: /usr/lib/softhsm/libsofthsm2.so
         SOFTHSM2_CONF: /tmp/softhsm2.conf
       run: ./ci.sh
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,24 @@ jobs:
       - name: "Installs SoftHSM and execute tests"
         uses: ./.github/actions/ci_script
 
+  tests-kryoptic:
+    name: Run tests against Kryoptic
+    runs-on: ubuntu-latest
+    container: fedora:rawhide
+    steps:
+      - name: Install dependencies
+        run: dnf -y install git cargo clang-devel kryoptic
+      - uses: actions/checkout@v2
+      - name: Test script
+        env:
+          KRYOPTIC_CONF: /tmp/kryoptic.sql
+          TEST_PKCS11_MODULE: /usr/lib64/pkcs11/libkryoptic_pkcs11.so
+        run: |
+          RUST_BACKTRACE=1 cargo build &&
+          RUST_BACKTRACE=1 cargo build --all-features &&
+          RUST_BACKTRACE=1 cargo test
+
+
   build-msrv:
     name: MSRV - Execute CI script
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Test script
         env:
-          PKCS11_SOFTHSM2_MODULE: /usr/lib/softhsm/libsofthsm2.so
+          TEST_PKCS11_MODULE: /usr/lib/softhsm/libsofthsm2.so
           SOFTHSM2_CONF: /tmp/softhsm2.conf
         run: |
           rm Cargo.lock

--- a/cryptoki-sys/build.rs
+++ b/cryptoki-sys/build.rs
@@ -91,8 +91,12 @@ mod generate {
             .dynamic_library_name("Pkcs11")
             // The PKCS11 library works in a slightly different way to most shared libraries. We have
             // to call `C_GetFunctionList`, which returns a list of pointers to the _actual_ library
-            // functions. This is the only function we need to create a binding for.
+            // functions (in PKCS #11 before 3.0). The PKCS #11 3.0 introduces the new functions
+            // `C_GetInterface` and `C_GetInterfaceList` to request the hew functions from 3.0 API.
+            // These are the only function we need to create a binding for.
             .allowlist_function("C_GetFunctionList")
+            .allowlist_function("C_GetInterfaceList")
+            .allowlist_function("C_GetInterface")
             // This is needed because no types will be generated if `allowlist_function` is used.
             // Unsure if this is a bug.
             .allowlist_type("*")

--- a/cryptoki/README.md
+++ b/cryptoki/README.md
@@ -22,7 +22,7 @@ You can follow the installation steps directly in the repository's README but he
 sudo apt install libsofthsm2
 mkdir /tmp/tokens
 echo "directories.tokendir = /tmp/tokens" > /tmp/softhsm2.conf
-export PKCS11_SOFTHSM2_MODULE="/usr/lib/softhsm/libsofthsm2.so"
+export TEST_PKCS11_MODULE="/usr/lib/softhsm/libsofthsm2.so"
 export SOFTHSM2_CONF="/tmp/softhsm2.conf"
 cargo run --example generate_key_pair
 ```
@@ -43,7 +43,7 @@ use std::env;
 
 // initialize a new Pkcs11 object using the module from the env variable
 let pkcs11 = Pkcs11::new(
-    env::var("PKCS11_SOFTHSM2_MODULE")
+    env::var("TEST_PKCS11_MODULE")
         .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
 )?;
 

--- a/cryptoki/examples/generate_key_pair.rs
+++ b/cryptoki/examples/generate_key_pair.rs
@@ -15,7 +15,7 @@ pub static SO_PIN: &str = "abcdef";
 fn main() -> testresult::TestResult {
     // initialize a new Pkcs11 object using the module from the env variable
     let pkcs11 = Pkcs11::new(
-        env::var("PKCS11_SOFTHSM2_MODULE")
+        env::var("TEST_PKCS11_MODULE")
             .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
     )?;
 

--- a/cryptoki/src/context/general_purpose.rs
+++ b/cryptoki/src/context/general_purpose.rs
@@ -44,6 +44,17 @@ macro_rules! check_fn {
     }};
 }
 
+macro_rules! check_30_fn {
+    ($pkcs11:expr, $func_name:ident) => {{
+        let func = paste! { $pkcs11
+            .impl_
+                .function_list_30
+                .map(|f| f.[<C_ $func_name>])
+        };
+        func.is_some()
+    }};
+}
+
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone)]
 /// Enumeration of all functions defined by the PKCS11 spec
@@ -116,6 +127,31 @@ pub enum Function {
     GetFunctionStatus,
     CancelFunction,
     WaitForSlotEvent,
+    /* PKCS #11 3.0 */
+    GetInterfaceList,
+    GetInterface,
+    LoginUser,
+    SessionCancel,
+    MessageEncryptInit,
+    EncryptMessage,
+    EncryptMessageBegin,
+    EncryptMessageNext,
+    MessageEncryptFinal,
+    MessageDecryptInit,
+    DecryptMessage,
+    DecryptMessageBegin,
+    DecryptMessageNext,
+    MessageDecryptFinal,
+    MessageSignInit,
+    SignMessage,
+    SignMessageBegin,
+    SignMessageNext,
+    MessageSignFinal,
+    MessageVerifyInit,
+    VerifyMessage,
+    VerifyMessageBegin,
+    VerifyMessageNext,
+    MessageVerifyFinal,
 }
 
 impl Display for Function {
@@ -195,5 +231,30 @@ pub(super) fn is_fn_supported(ctx: &Pkcs11, function: Function) -> bool {
         Function::GetFunctionStatus => check_fn!(ctx, GetFunctionStatus),
         Function::CancelFunction => check_fn!(ctx, CancelFunction),
         Function::WaitForSlotEvent => check_fn!(ctx, WaitForSlotEvent),
+        /* PKCS #11 3.0 */
+        Function::GetInterfaceList => check_30_fn!(ctx, GetInterfaceList),
+        Function::GetInterface => check_30_fn!(ctx, GetInterface),
+        Function::LoginUser => check_30_fn!(ctx, LoginUser),
+        Function::SessionCancel => check_30_fn!(ctx, SessionCancel),
+        Function::MessageEncryptInit => check_30_fn!(ctx, MessageEncryptInit),
+        Function::EncryptMessage => check_30_fn!(ctx, EncryptMessage),
+        Function::EncryptMessageBegin => check_30_fn!(ctx, EncryptMessageBegin),
+        Function::EncryptMessageNext => check_30_fn!(ctx, EncryptMessageNext),
+        Function::MessageEncryptFinal => check_30_fn!(ctx, MessageEncryptFinal),
+        Function::MessageDecryptInit => check_30_fn!(ctx, MessageDecryptInit),
+        Function::DecryptMessage => check_30_fn!(ctx, DecryptMessage),
+        Function::DecryptMessageBegin => check_30_fn!(ctx, DecryptMessageBegin),
+        Function::DecryptMessageNext => check_30_fn!(ctx, DecryptMessageNext),
+        Function::MessageDecryptFinal => check_30_fn!(ctx, MessageDecryptFinal),
+        Function::MessageSignInit => check_30_fn!(ctx, MessageSignInit),
+        Function::SignMessage => check_30_fn!(ctx, SignMessage),
+        Function::SignMessageBegin => check_30_fn!(ctx, SignMessageBegin),
+        Function::SignMessageNext => check_30_fn!(ctx, SignMessageNext),
+        Function::MessageSignFinal => check_30_fn!(ctx, MessageSignFinal),
+        Function::MessageVerifyInit => check_30_fn!(ctx, MessageVerifyInit),
+        Function::VerifyMessage => check_30_fn!(ctx, VerifyMessage),
+        Function::VerifyMessageBegin => check_30_fn!(ctx, VerifyMessageBegin),
+        Function::VerifyMessageNext => check_30_fn!(ctx, VerifyMessageNext),
+        Function::MessageVerifyFinal => check_30_fn!(ctx, MessageVerifyFinal),
     }
 }

--- a/cryptoki/src/context/session_management.rs
+++ b/cryptoki/src/context/session_management.rs
@@ -50,7 +50,7 @@ impl Pkcs11 {
     /// use cryptoki::context::Pkcs11;
     ///
     /// let mut client = Pkcs11::new(
-    ///     std::env::var("PKCS11_SOFTHSM2_MODULE")
+    ///     std::env::var("TEST_PKCS11_MODULE")
     ///        .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
     /// )?;
     /// client.initialize(cryptoki::context::CInitializeArgs::OsThreads)?;

--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -1378,6 +1378,8 @@ pub enum AttributeInfo {
     Sensitive,
     /// The attribute is available to get from the object and has the specified size in bytes.
     Available(usize),
+    /// The attribute is not available.
+    Unavailable,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/cryptoki/src/session/object_management.rs
+++ b/cryptoki/src/session/object_management.rs
@@ -39,7 +39,7 @@ const MAX_OBJECT_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) 
 ///
 /// # fn main() -> testresult::TestResult {
 /// # let pkcs11 = Pkcs11::new(
-/// #    env::var("PKCS11_SOFTHSM2_MODULE")
+/// #    env::var("TEST_PKCS11_MODULE")
 /// #        .unwrap_or_else(|_| "/usr/local/lib/libsofthsm2.so".to_string()),
 /// # )?;
 /// #
@@ -282,7 +282,7 @@ impl Session {
     /// # use cryptoki::object::{Attribute, AttributeType, CertificateType, ObjectClass, ObjectHandle};
     /// #
     /// # let mut client = Pkcs11::new(
-    /// #    std::env::var("PKCS11_SOFTHSM2_MODULE")
+    /// #    std::env::var("TEST_PKCS11_MODULE")
     /// #       .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
     /// # )?;
     /// # client.initialize(cryptoki::context::CInitializeArgs::OsThreads)?;
@@ -401,7 +401,7 @@ impl Session {
     /// use std::env;
     ///
     /// let mut pkcs11 = Pkcs11::new(
-    ///         env::var("PKCS11_SOFTHSM2_MODULE")
+    ///         env::var("TEST_PKCS11_MODULE")
     ///             .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
     ///     )
     ///     .unwrap();

--- a/cryptoki/src/session/object_management.rs
+++ b/cryptoki/src/session/object_management.rs
@@ -454,7 +454,11 @@ impl Session {
                 ))
             } {
                 Rv::Ok => {
-                    results.push(AttributeInfo::Available(template[0].ulValueLen.try_into()?))
+                    if template[0].ulValueLen == CK_UNAVAILABLE_INFORMATION {
+                        results.push(AttributeInfo::Unavailable)
+                    } else {
+                        results.push(AttributeInfo::Available(template[0].ulValueLen.try_into()?))
+                    }
                 }
                 Rv::Error(RvError::AttributeSensitive) => results.push(AttributeInfo::Sensitive),
                 Rv::Error(RvError::AttributeTypeInvalid) => {

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -268,6 +268,11 @@ fn encrypt_decrypt() -> TestResult {
 #[test]
 #[serial]
 fn derive_key() -> TestResult {
+    /* FIXME: This is now broken in Kryoptic: https://github.com/latchset/kryoptic/issues/184 */
+    if !is_softhsm() {
+        /* return Ignore(); */
+        return Ok(());
+    }
     let (pkcs11, slot) = init_pins();
 
     // open a session
@@ -566,6 +571,12 @@ fn session_objecthandle_iterator() -> testresult::TestResult {
 #[test]
 #[serial]
 fn wrap_and_unwrap_key() {
+    /* FIXME: This is now broken in Kryoptic: https://github.com/latchset/kryoptic/issues/184 */
+    if !is_softhsm() {
+        /* return Ignore(); */
+        return;
+    }
+
     let (pkcs11, slot) = init_pins();
     // open a session
     let session = pkcs11.open_rw_session(slot).unwrap();
@@ -996,6 +1007,11 @@ fn test_clone_initialize() {
 #[test]
 #[serial]
 fn aes_key_attributes_test() -> TestResult {
+    /* FIXME: This is now broken in Kryoptic: https://github.com/latchset/kryoptic/issues/182 */
+    if !is_softhsm() {
+        /* return Ignore(); */
+        return Ok(());
+    }
     let (pkcs11, slot) = init_pins();
 
     // open a session

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -947,6 +947,18 @@ fn is_fn_supported_test() {
         pkcs11.is_fn_supported(Function::DigestFinal),
         "C_DigestFinal function reports as not supported"
     );
+    if is_softhsm() {
+        // the SoftHSM does not have PKCS#11 3.0 API so this function is not present
+        assert!(
+            !pkcs11.is_fn_supported(Function::MessageEncryptInit),
+            "C_MessageEncryptInit function reports supported for SoftHSM"
+        );
+    } else {
+        assert!(
+            pkcs11.is_fn_supported(Function::MessageEncryptInit),
+            "C_MessageEncryptInit function reports as not supported"
+        );
+    }
 }
 
 #[test]

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -46,10 +46,11 @@ fn sign_verify() -> TestResult {
         Attribute::Private(false),
         Attribute::PublicExponent(public_exponent),
         Attribute::ModulusBits(modulus_bits.into()),
+        Attribute::Verify(true),
     ];
 
     // priv key template
-    let priv_key_template = vec![Attribute::Token(true)];
+    let priv_key_template = vec![Attribute::Token(true), Attribute::Sign(true)];
 
     // generate a key pair
     let (public, private) =
@@ -93,7 +94,7 @@ fn sign_verify_eddsa() -> TestResult {
         ]),
     ];
 
-    let priv_key_template = vec![Attribute::Token(true)];
+    let priv_key_template = vec![Attribute::Token(true), Attribute::Sign(true)];
 
     let (public, private) =
         session.generate_key_pair(&mechanism, &pub_key_template, &priv_key_template)?;
@@ -136,7 +137,7 @@ fn sign_verify_eddsa_with_ed25519_schemes() -> TestResult {
         ]),
     ];
 
-    let priv_key_template = vec![Attribute::Token(true)];
+    let priv_key_template = vec![Attribute::Token(true), Attribute::Sign(true)];
 
     let (public, private) =
         session.generate_key_pair(&mechanism, &pub_key_template, &priv_key_template)?;
@@ -186,7 +187,7 @@ fn sign_verify_eddsa_with_ed448_schemes() -> TestResult {
         ]),
     ];
 
-    let priv_key_template = vec![Attribute::Token(true)];
+    let priv_key_template = vec![Attribute::Token(true), Attribute::Sign(true)];
 
     let (public, private) =
         session.generate_key_pair(&mechanism, &pub_key_template, &priv_key_template)?;
@@ -1353,9 +1354,16 @@ fn rsa_pkcs_oaep_empty() -> TestResult {
     let session = pkcs11.open_rw_session(slot)?;
     session.login(UserType::User, Some(&AuthPin::new(USER_PIN.into())))?;
 
-    let pub_key_template = [Attribute::ModulusBits(2048.into())];
-    let (pubkey, privkey) =
-        session.generate_key_pair(&Mechanism::RsaPkcsKeyPairGen, &pub_key_template, &[])?;
+    let pub_key_template = [
+        Attribute::ModulusBits(2048.into()),
+        Attribute::Encrypt(true),
+    ];
+    let priv_key_template = [Attribute::Decrypt(true)];
+    let (pubkey, privkey) = session.generate_key_pair(
+        &Mechanism::RsaPkcsKeyPairGen,
+        &pub_key_template,
+        &priv_key_template,
+    )?;
     let oaep = PkcsOaepParams::new(
         MechanismType::SHA1,
         PkcsMgfType::MGF1_SHA1,
@@ -1380,9 +1388,16 @@ fn rsa_pkcs_oaep_with_data() -> TestResult {
     let session = pkcs11.open_rw_session(slot)?;
     session.login(UserType::User, Some(&AuthPin::new(USER_PIN.into())))?;
 
-    let pub_key_template = [Attribute::ModulusBits(2048.into())];
-    let (pubkey, privkey) =
-        session.generate_key_pair(&Mechanism::RsaPkcsKeyPairGen, &pub_key_template, &[])?;
+    let pub_key_template = [
+        Attribute::ModulusBits(2048.into()),
+        Attribute::Encrypt(true),
+    ];
+    let priv_key_template = vec![Attribute::Decrypt(true)];
+    let (pubkey, privkey) = session.generate_key_pair(
+        &Mechanism::RsaPkcsKeyPairGen,
+        &pub_key_template,
+        &priv_key_template,
+    )?;
     let oaep = PkcsOaepParams::new(
         MechanismType::SHA1,
         PkcsMgfType::MGF1_SHA1,
@@ -1523,6 +1538,7 @@ fn sign_verify_sha1_hmac() -> TestResult {
         Attribute::Private(true),
         Attribute::Sensitive(true),
         Attribute::Sign(true),
+        Attribute::Verify(true),
         Attribute::KeyType(KeyType::GENERIC_SECRET),
         Attribute::Class(ObjectClass::SECRET_KEY),
         Attribute::ValueLen(256.into()),
@@ -1552,6 +1568,7 @@ fn sign_verify_sha224_hmac() -> TestResult {
         Attribute::Private(true),
         Attribute::Sensitive(true),
         Attribute::Sign(true),
+        Attribute::Verify(true),
         Attribute::KeyType(KeyType::GENERIC_SECRET),
         Attribute::Class(ObjectClass::SECRET_KEY),
         Attribute::ValueLen(256.into()),
@@ -1581,6 +1598,7 @@ fn sign_verify_sha256_hmac() -> TestResult {
         Attribute::Private(true),
         Attribute::Sensitive(true),
         Attribute::Sign(true),
+        Attribute::Verify(true),
         Attribute::KeyType(KeyType::GENERIC_SECRET),
         Attribute::Class(ObjectClass::SECRET_KEY),
         Attribute::ValueLen(256.into()),
@@ -1610,6 +1628,7 @@ fn sign_verify_sha384_hmac() -> TestResult {
         Attribute::Private(true),
         Attribute::Sensitive(true),
         Attribute::Sign(true),
+        Attribute::Verify(true),
         Attribute::KeyType(KeyType::GENERIC_SECRET),
         Attribute::Class(ObjectClass::SECRET_KEY),
         Attribute::ValueLen(256.into()),
@@ -1639,6 +1658,7 @@ fn sign_verify_sha512_hmac() -> TestResult {
         Attribute::Private(true),
         Attribute::Sensitive(true),
         Attribute::Sign(true),
+        Attribute::Verify(true),
         Attribute::KeyType(KeyType::GENERIC_SECRET),
         Attribute::Class(ObjectClass::SECRET_KEY),
         Attribute::ValueLen(256.into()),

--- a/cryptoki/tests/common.rs
+++ b/cryptoki/tests/common.rs
@@ -13,7 +13,7 @@ pub static SO_PIN: &str = "abcdef";
 
 pub fn get_pkcs11() -> Pkcs11 {
     Pkcs11::new(
-        env::var("PKCS11_SOFTHSM2_MODULE")
+        env::var("TEST_PKCS11_MODULE")
             .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
     )
     .unwrap()

--- a/cryptoki/tests/common.rs
+++ b/cryptoki/tests/common.rs
@@ -11,12 +11,17 @@ pub static USER_PIN: &str = "fedcba";
 // The default SO pin
 pub static SO_PIN: &str = "abcdef";
 
+fn get_pkcs11_path() -> String {
+    env::var("TEST_PKCS11_MODULE")
+        .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string())
+}
+
+pub fn is_softhsm() -> bool {
+    get_pkcs11_path().contains("softhsm")
+}
+
 pub fn get_pkcs11() -> Pkcs11 {
-    Pkcs11::new(
-        env::var("TEST_PKCS11_MODULE")
-            .unwrap_or_else(|_| "/usr/local/lib/softhsm/libsofthsm2.so".to_string()),
-    )
-    .unwrap()
+    Pkcs11::new(get_pkcs11_path()).unwrap()
 }
 
 pub fn init_pins() -> (Pkcs11, Slot) {


### PR DESCRIPTION
The PKCS#11 3.0 introduces new APIs with new function list to reach out to new functions. The 3.2 will come with yet another function list. This requires a change in the initialization. While most of the tokens now support also the 2.4 way, using new APIs is not possible through the old function list.

This is adding the support for the new functions and tests against another PKCS#11 module, fixing some incompatibilities that I found in the testsuite here. Its a bit mixed bag and it also found some issues in the kryoptic that we need to handle, such as latchset/kryoptic#182 and latchset/kryoptic#184 so opening as a draft for now.