### PR TITLE
Fixed failing tests for multi-part operations

### DIFF
--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -228,10 +228,12 @@ fn sign_verify_multipart() -> TestResult {
 
     let pub_key_template = vec![
         Attribute::Token(true),
+        Attribute::Private(false),
         Attribute::PublicExponent(public_exponent),
         Attribute::ModulusBits(modulus_bits.into()),
+        Attribute::Verify(true),
     ];
-    let priv_key_template = vec![Attribute::Token(true)];
+    let priv_key_template = vec![Attribute::Token(true), Attribute::Sign(true)];
 
     // Generate keypair
     let (pub_key, priv_key) = session.generate_key_pair(
@@ -331,10 +333,12 @@ fn sign_verify_multipart_already_initialized() -> TestResult {
 
     let pub_key_template = vec![
         Attribute::Token(true),
+        Attribute::Private(false),
         Attribute::PublicExponent(public_exponent),
         Attribute::ModulusBits(modulus_bits.into()),
+        Attribute::Verify(true),
     ];
-    let priv_key_template = vec![Attribute::Token(true)];
+    let priv_key_template = vec![Attribute::Token(true), Attribute::Sign(true)];
 
     // Generate keypair
     let (pub_key, priv_key) = session.generate_key_pair(
@@ -437,7 +441,10 @@ fn encrypt_decrypt_multipart() -> TestResult {
     // Generate key (currently SoftHSM only supports multi-part encrypt/decrypt for symmetric crypto)
     let template = vec![
         Attribute::Token(true),
+        Attribute::Private(false),
         Attribute::ValueLen((128 / 8).into()),
+        Attribute::Encrypt(true),
+        Attribute::Decrypt(true),
     ];
     let key = session.generate_key(&Mechanism::AesKeyGen, &template)?;
 
@@ -539,7 +546,10 @@ fn encrypt_decrypt_multipart_already_initialized() -> TestResult {
     // Generate key (currently SoftHSM only supports multi-part encrypt/decrypt for symmetric crypto)
     let template = vec![
         Attribute::Token(true),
+        Attribute::Private(false),
         Attribute::ValueLen((128 / 8).into()),
+        Attribute::Encrypt(true),
+        Attribute::Decrypt(true),
     ];
     let key = session.generate_key(&Mechanism::AesKeyGen, &template)?;
 
@@ -1655,6 +1665,7 @@ fn sha256_digest_multipart_with_key() -> TestResult {
     // Create a key to add to the digest
     let key_template = vec![
         Attribute::Token(true),
+        Attribute::Private(false),
         Attribute::ValueLen((256 / 8).into()),
         // Key must be non-sensitive and extractable to get its bytes and digest them directly, for comparison
         Attribute::Sensitive(false),

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -464,7 +464,7 @@ fn encrypt_decrypt_multipart() -> TestResult {
         0x33, 0x99, 0x77,
     ];
 
-    // // Encrypt data in parts
+    // Encrypt data in parts
     session.encrypt_init(&Mechanism::AesEcb, key)?;
 
     let mut encrypted_data = vec![];

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -1671,9 +1671,12 @@ fn sha256_digest_multipart() -> TestResult {
 
 #[test]
 #[serial]
-// Not all backends support extracting a secret key value, needed to validate this test
-#[ignore]
 fn sha256_digest_multipart_with_key() -> TestResult {
+    // FIXME: Getting value from sensitive objects is now broken in Kryoptic: https://github.com/latchset/kryoptic/issues/193
+    if !is_softhsm() {
+        return Ok(());
+    }
+
     let (pkcs11, slot) = init_pins();
 
     // Open a session and log in

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -1671,6 +1671,8 @@ fn sha256_digest_multipart() -> TestResult {
 
 #[test]
 #[serial]
+// Not all backends support extracting a secret key value, needed to validate this test
+#[ignore]
 fn sha256_digest_multipart_with_key() -> TestResult {
     let (pkcs11, slot) = init_pins();
 

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -363,8 +363,10 @@ fn sign_verify_multipart_already_initialized() -> TestResult {
         Error::Pkcs11(RvError::OperationActive, Function::SignInit)
     ));
 
-    // Make sure signing operation is over before trying same with verification
-    session.sign_final()?;
+    // Make sure signing operation is over before trying same with verification.
+    // Some backends will reset the ongoing operation after the failed 2nd call to
+    // sign_init(), so we should not unwrap the result of this call.
+    let _ = session.sign_final();
 
     // Initialize verification operation twice in a row
     session.verify_init(&Mechanism::Sha256RsaPkcs, pub_key)?;
@@ -575,8 +577,10 @@ fn encrypt_decrypt_multipart_already_initialized() -> TestResult {
         Error::Pkcs11(RvError::OperationActive, Function::EncryptInit)
     ));
 
-    // Make sure encryption operation is over before trying same with decryption
-    session.encrypt_final()?;
+    // Make sure encryption operation is over before trying same with decryption.
+    // Some backends will reset the ongoing operation after the failed 2nd call to
+    // encrypt_init(), so we should not unwrap the result of this call.
+    let _ = session.encrypt_final();
 
     // Initialize encryption operation twice in a row
     session.decrypt_init(&Mechanism::AesEcb, key)?;

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -283,36 +283,40 @@ fn sign_verify_multipart_not_initialized() -> TestResult {
     let result = session.sign_update(&data);
 
     assert!(result.is_err());
+    // The exact error returned is inconsistent between backends, so we only match on the function
     assert!(matches!(
         result.unwrap_err(),
-        Error::Pkcs11(RvError::OperationNotInitialized, Function::SignUpdate)
+        Error::Pkcs11(_, Function::SignUpdate)
     ));
 
     // Attempt to finalize signing without an operation having been initialized
     let result = session.sign_final();
 
     assert!(result.is_err());
+    // The exact error returned is inconsistent between backends, so we only match on the function
     assert!(matches!(
         result.unwrap_err(),
-        Error::Pkcs11(RvError::OperationNotInitialized, Function::SignFinal)
+        Error::Pkcs11(_, Function::SignFinal)
     ));
 
     // Attempt to update verification without an operation having been initialized
     let result = session.verify_update(&data);
 
     assert!(result.is_err());
+    // The exact error returned is inconsistent between backends, so we only match on the function
     assert!(matches!(
         result.unwrap_err(),
-        Error::Pkcs11(RvError::OperationNotInitialized, Function::VerifyUpdate)
+        Error::Pkcs11(_, Function::VerifyUpdate)
     ));
 
     // Attempt to finalize verification without an operation having been initialized
     let result = session.verify_final(&signature);
 
     assert!(result.is_err());
+    // The exact error returned is inconsistent between backends, so we only match on the function
     assert!(matches!(
         result.unwrap_err(),
-        Error::Pkcs11(RvError::OperationNotInitialized, Function::VerifyFinal)
+        Error::Pkcs11(_, Function::VerifyFinal)
     ));
 
     Ok(())
@@ -499,36 +503,40 @@ fn encrypt_decrypt_multipart_not_initialized() -> TestResult {
     let result = session.encrypt_update(&data);
 
     assert!(result.is_err());
+    // The exact error returned is inconsistent between backends, so we only match on the function
     assert!(matches!(
         result.unwrap_err(),
-        Error::Pkcs11(RvError::OperationNotInitialized, Function::EncryptUpdate)
+        Error::Pkcs11(_, Function::EncryptUpdate)
     ));
 
     // Attempt to finalize encryption without an operation having been initialized
     let result = session.encrypt_final();
 
     assert!(result.is_err());
+    // The exact error returned is inconsistent between backends, so we only match on the function
     assert!(matches!(
         result.unwrap_err(),
-        Error::Pkcs11(RvError::OperationNotInitialized, Function::EncryptFinal)
+        Error::Pkcs11(_, Function::EncryptFinal)
     ));
 
     // Attempt to update decryption without an operation having been initialized
     let result = session.decrypt_update(&data);
 
     assert!(result.is_err());
+    // The exact error returned is inconsistent between backends, so we only match on the function
     assert!(matches!(
         result.unwrap_err(),
-        Error::Pkcs11(RvError::OperationNotInitialized, Function::DecryptUpdate)
+        Error::Pkcs11(_, Function::DecryptUpdate)
     ));
 
     // Attempt to finalize decryption without an operation having been initialized
     let result = session.decrypt_final();
 
     assert!(result.is_err());
+    // The exact error returned is inconsistent between backends, so we only match on the function
     assert!(matches!(
         result.unwrap_err(),
-        Error::Pkcs11(RvError::OperationNotInitialized, Function::DecryptFinal)
+        Error::Pkcs11(_, Function::DecryptFinal)
     ));
 
     Ok(())
@@ -1718,18 +1726,20 @@ fn sha256_digest_multipart_not_initialized() -> TestResult {
     let result = session.digest_update(&data);
 
     assert!(result.is_err());
+    // The exact error returned is inconsistent between backends, so we only match on the function
     assert!(matches!(
         result.unwrap_err(),
-        Error::Pkcs11(RvError::OperationNotInitialized, Function::DigestUpdate)
+        Error::Pkcs11(_, Function::DigestUpdate)
     ));
 
     // Attempt to finalize digest without an operation having been initialized
     let result = session.digest_final();
 
     assert!(result.is_err());
+    // The exact error returned is inconsistent between backends, so we only match on the function
     assert!(matches!(
         result.unwrap_err(),
-        Error::Pkcs11(RvError::OperationNotInitialized, Function::DigestFinal)
+        Error::Pkcs11(_, Function::DigestFinal)
     ));
 
     Ok(())

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -1682,7 +1682,7 @@ fn sha256_digest_multipart_with_key() -> TestResult {
     let key_template = vec![
         Attribute::Token(true),
         Attribute::Private(false),
-        Attribute::ValueLen((256 / 8).into()),
+        Attribute::ValueLen((AES128_BLOCK_SIZE as u64).into()),
         // Key must be non-sensitive and extractable to get its bytes and digest them directly, for comparison
         Attribute::Sensitive(false),
         Attribute::Extractable(true),


### PR DESCRIPTION
Author: Jacob Prud'homme
Email: [2160185+jacobprudhomme@users.noreply.github.com](mailto:2160185+jacobprudhomme@users.noreply.github.com)

# Description

In tests relating to multi-part operations, added missing attributes to key templates, since Kryoptic was throwing errors about said keys not having the correct attributes set on them to perform certain operations (see [here](https://github.com/parallaxsecond/rust-cryptoki/pull/252#issuecomment-2761295928))

## Summary of Changes

* Tweaked tests for multipart encrypt/decrypt/verify/sign/digest functionality
  * Added missing attributes to templates for keys
  * Asserted that only a generic PKCS#11 error happens for the `*_not_initialized` tests, since the exact error returned by various backends is different
  * Similarly, changed the `*_already_initialized` tests to account for differing behaviour between backends
  * Ignored `sha256_digest_key` test, since it seems to be impossible to test the desired functionality on all backends for the moment (in particular, extracting the value from a secret key marked `Extractable` and not `Sensitive` is not always supported)