### PR TITLE
Bump rust edition to 2021

### DIFF
--- a/cryptoki-sys/Cargo.toml
+++ b/cryptoki-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cryptoki-sys"
 version = "0.3.0"
 authors = ["Contributors to the Parsec project"]
-edition = '2018'
+edition = '2021'
 description = "FFI wrapper around the PKCS #11 API"
 readme = "README.md"
 keywords = ["pkcs11", "cryptoki", "hsm"]

--- a/cryptoki/Cargo.toml
+++ b/cryptoki/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cryptoki"
 version = "0.9.0"
 authors = ["Contributors to the Parsec project"]
-edition = '2018'
+edition = '2021'
 description = "Rust-native wrapper around the PKCS #11 API"
 readme = "README.md"
 keywords = ["pkcs11", "cryptoki", "hsm"]


### PR DESCRIPTION
Turns out we used in one of the last changes a feature from edition 2021, which current warns in main like this:
```
warning: panic message contains an unused formatting placeholder
    --> cryptoki/tests/basic.rs:1043:63
     |
1043 |             "Only 3.0 and 3.2 versions are expected but got 3.{minor}"
     |                                                               ^^^^^^^
     |
     = note: this message is not used as a format string when given without arguments, but will be in Rust 2021
     = note: `#[warn(non_fmt_panics)]` on by default
help: add the missing argument
     |
1043 |             "Only 3.0 and 3.2 versions are expected but got 3.{minor}", ...
     |                                                                       +++++
help: or add a "{}" format string to use the message literally
     |
1043 |             "{}", "Only 3.0 and 3.2 versions are expected but got 3.{minor}"
     |             +++++
```
This made me wondering why we are on the 2018 these days and it looks like the only thing to fix this is a bump of the rust edition  to 2021.

https://github.com/parallaxsecond/rust-cryptoki/pull/262#discussion_r2065813985

I did not notice any side effects locally.