### PR TITLE
#267 Modify get_attribute_info_map to take slice instead of vec

### DIFF
--- a/cryptoki/src/session/object_management.rs
+++ b/cryptoki/src/session/object_management.rs
@@ -486,9 +486,9 @@ impl Session {
     pub fn get_attribute_info_map(
         &self,
         object: ObjectHandle,
-        attributes: Vec<AttributeType>,
+        attributes: &[AttributeType],
     ) -> Result<HashMap<AttributeType, AttributeInfo>> {
-        let attrib_info = self.get_attribute_info(object, attributes.as_slice())?;
+        let attrib_info = self.get_attribute_info(object, attributes)?;
 
         Ok(attributes
             .iter()

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -1192,8 +1192,9 @@ fn get_attribute_info_test() -> TestResult {
         session.generate_key_pair(&mechanism, &pub_key_template, &priv_key_template)?;
 
     let pub_attribs = vec![AttributeType::PublicExponent, AttributeType::Modulus];
-    let mut priv_attribs = pub_attribs.clone();
-    priv_attribs.push(AttributeType::PrivateExponent);
+    let mut priv_attribs = [
+        AttributeType::PublicExponent, AttributeType::Modulus, AttributeType::PrivateExponent
+    ];
 
     let attrib_info = session.get_attribute_info(public, &pub_attribs)?;
     let hash = pub_attribs
@@ -1234,7 +1235,7 @@ fn get_attribute_info_test() -> TestResult {
         _ => panic!("Private Exponent of RSA private key should be sensitive"),
     }
 
-    let hash = session.get_attribute_info_map(private, priv_attribs)?;
+    let hash = session.get_attribute_info_map(private, &priv_attribs)?;
     if let AttributeInfo::Available(size) = hash[&AttributeType::Modulus] {
         assert_eq!(size, 2048 / 8);
     } else {

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -1198,7 +1198,9 @@ fn get_attribute_info_test() -> TestResult {
 
     let pub_attribs = vec![AttributeType::PublicExponent, AttributeType::Modulus];
     let mut priv_attribs = [
-        AttributeType::PublicExponent, AttributeType::Modulus, AttributeType::PrivateExponent
+        AttributeType::PublicExponent,
+        AttributeType::Modulus,
+        AttributeType::PrivateExponent,
     ];
 
     let attrib_info = session.get_attribute_info(public, &pub_attribs)?;


### PR DESCRIPTION
Modified the argument from vec to slice as highlighted in #267 and updated the only test case that used get_attribute_info_map.