### PR TITLE
Add workspace resolver to fix a build warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["cryptoki", "cryptoki-sys"]
+resolver = "2"


### PR DESCRIPTION
Without explicit resolver `cargo` will use `resolver = "1"` and print the following warning:

```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
```