### PR TITLE
Add simple build on Windows CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
       - name: "Installs SoftHSM and execute tests"
         uses: ./.github/actions/ci_script
 
+  build-windows:
+    name: Build on Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo check
+
   tests-kryoptic:
     name: Run tests against Kryoptic
     runs-on: ubuntu-latest


### PR DESCRIPTION
Okay, it seems to build on Windows... now... we need a soft token to run the tests with... any suggestions? :sweat_smile: 