### PR TITLE
Fix typos in doc texts

### DIFF
--- a/cryptoki/src/mechanism/eddsa.rs
+++ b/cryptoki/src/mechanism/eddsa.rs
@@ -120,7 +120,7 @@ impl EddsaParams<'_> {
     ///
     /// # Arguments
     ///
-    /// * `params` - The CK_EDDSA_PARAMS structure.
+    /// * `scheme` - The EdDSA signature scheme.
     ///
     /// # Returns
     ///

--- a/cryptoki/src/session/message_decryption.rs
+++ b/cryptoki/src/session/message_decryption.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-//! Encrypting data
+//! Decrypting messages
 
 use crate::context::Function;
 use crate::error::{Result, Rv};

--- a/cryptoki/src/session/message_encryption.rs
+++ b/cryptoki/src/session/message_encryption.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-//! Encrypting data
+//! Encrypting messages
 
 use crate::context::Function;
 use crate::error::{Result, Rv};


### PR DESCRIPTION
I found and fixed some typos in #270, but the whole PR turned out that it won't get merged any time soon so moved the non-controversial documentation fixes from there to separate PR, that should be easy to review and merge.