### PR TITLE
Set installed toolchain as default and bump MSRV to 1.77

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           - riscv64gc-unknown-linux-gnu
         toolchain:
           - stable
-          - "1.66.0" # MSRV
+          - "1.77" # MSRV
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
@@ -97,7 +97,7 @@ jobs:
           - x86_64-unknown-linux-gnu
         toolchain:
           - stable
-          - "1.66.0" # MSRV
+          - "1.77" # MSRV
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain

--- a/cryptoki-sys/Cargo.toml
+++ b/cryptoki-sys/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["api-bindings", "external-ffi-bindings", "cryptography", "hardware
 license = "Apache-2.0"
 repository = "https://github.com/parallaxsecond/rust-cryptoki"
 documentation = "https://docs.rs/crate/cryptoki-sys"
-rust-version = "1.66.0"
+rust-version = "1.77"
 
 [build-dependencies]
 bindgen = { version = "0.70.1", optional = true }

--- a/cryptoki/Cargo.toml
+++ b/cryptoki/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["api-bindings", "external-ffi-bindings", "cryptography", "hardware
 license = "Apache-2.0"
 repository = "https://github.com/parallaxsecond/rust-cryptoki"
 documentation = "https://docs.rs/crate/cryptoki"
-rust-version = "1.66.0"
+rust-version = "1.77"
 
 [dependencies]
 bitflags = "1.3"


### PR DESCRIPTION
The docs for the action indicate that unless specified the toolchain will not be used by default.