### PR TITLE
Add support for Pkcs#11 Profile objects

### DIFF
--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -94,6 +94,8 @@ pub enum AttributeType {
     ObjectId,
     /// DER encoding of the attribute certificate's subject field
     Owner,
+    /// Algorithm-specific parameter set
+    ParameterSet,
     /// Prime number value of a key
     Prime,
     /// The prime `p` of an RSA private key
@@ -108,6 +110,8 @@ pub enum AttributeType {
     PublicExponent,
     /// DER-encoding of the SubjectPublicKeyInfo
     PublicKeyInfo,
+    /// Seed to derive private key
+    Seed,
     /// Determines if the key is sensitive
     Sensitive,
     /// DER encoding of the certificate serial number
@@ -144,10 +148,6 @@ pub enum AttributeType {
     Wrap,
     /// Indicates that the key can only be wrapped with a wrapping key that has the Trusted attribute
     WrapWithTrusted,
-    /// Seed to derive private key
-    Seed,
-    /// Algorithm-specific parameter set
-    ParameterSet,
 }
 
 impl AttributeType {

--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -1278,6 +1278,12 @@ impl ObjectClass {
     pub const MECHANISM: ObjectClass = ObjectClass { val: CKO_MECHANISM };
     /// An OTP key object
     pub const OTP_KEY: ObjectClass = ObjectClass { val: CKO_OTP_KEY };
+    /// Profile object
+    pub const PROFILE: ObjectClass = ObjectClass { val: CKO_PROFILE };
+    /// Validation object
+    pub const VALIDATION: ObjectClass = ObjectClass {
+        val: CKO_VALIDATION,
+    };
 
     pub(crate) fn stringify(class: CK_OBJECT_CLASS) -> String {
         match class {
@@ -1290,6 +1296,8 @@ impl ObjectClass {
             CKO_DOMAIN_PARAMETERS => String::from(stringify!(CKO_DOMAIN_PARAMETERS)),
             CKO_MECHANISM => String::from(stringify!(CKO_MECHANISM)),
             CKO_OTP_KEY => String::from(stringify!(CKO_OTP_KEY)),
+            CKO_PROFILE => String::from(stringify!(CKO_PROFILE)),
+            CKO_VALIDATION => String::from(stringify!(CKO_VALIDATION)),
             _ => format!("unknown ({class:08x})"),
         }
     }
@@ -1329,6 +1337,8 @@ impl TryFrom<CK_OBJECT_CLASS> for ObjectClass {
             CKO_DOMAIN_PARAMETERS => Ok(ObjectClass::DOMAIN_PARAMETERS),
             CKO_MECHANISM => Ok(ObjectClass::MECHANISM),
             CKO_OTP_KEY => Ok(ObjectClass::OTP_KEY),
+            CKO_PROFILE => Ok(ObjectClass::PROFILE),
+            CKO_VALIDATION => Ok(ObjectClass::VALIDATION),
 
             _ => {
                 error!("Object class {} is not supported.", object_class);

--- a/cryptoki/src/session/object_management.rs
+++ b/cryptoki/src/session/object_management.rs
@@ -224,7 +224,7 @@ impl Session {
     /// * [`ObjectHandleIterator`] for more information on how to use the iterator
     /// * [`Session::iter_objects_with_cache_size`] for a way to specify the cache size
     #[inline(always)]
-    pub fn iter_objects(&self, template: &[Attribute]) -> Result<ObjectHandleIterator> {
+    pub fn iter_objects(&self, template: &[Attribute]) -> Result<ObjectHandleIterator<'_>> {
         self.iter_objects_with_cache_size(template, MAX_OBJECT_COUNT)
     }
 
@@ -248,7 +248,7 @@ impl Session {
         &self,
         template: &[Attribute],
         cache_size: NonZeroUsize,
-    ) -> Result<ObjectHandleIterator> {
+    ) -> Result<ObjectHandleIterator<'_>> {
         let template: Vec<CK_ATTRIBUTE> = template.iter().map(Into::into).collect();
         ObjectHandleIterator::new(self, template, cache_size)
     }


### PR DESCRIPTION
This allows selecting new object types, profiles, from the token and reading their attributes, consisting of a profile ID the token implements:

https://docs.oasis-open.org/pkcs11/pkcs11-profiles/v3.1/os/pkcs11-profiles-v3.1-os.html

The specs is a bit vague and my understanding is that the profiles can overlap, but are not always superset of some other profile, which makes me thinking the token can have several profile objects.

Currently, this is not implemented by neither kryoptic nor softhsm, but I filled a RFE for kryoptic (https://github.com/latchset/kryoptic/issues/305) so once we will have it in, I will try to write some test.