### PR TITLE
misc: Add simple containerfile to regenerate bindings

### DIFF
--- a/cryptoki-sys/Containerfile
+++ b/cryptoki-sys/Containerfile
@@ -1,0 +1,17 @@
+# Simple ubuntu container that can be used to regenerate bindings with the provided script
+# when one does not use ubuntu
+#
+# Instructions:
+# $ podman build -t rust-cryptoki .
+# $ podman run -v $PWD:/src:z rust-cryptoki
+#
+FROM ubuntu:latest
+RUN export DEBIAN_FRONTEND=noninteractive; \
+    export DEBCONF_NONINTERACTIVE_SEEN=true; \
+    echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections; \
+    echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections; \
+    apt-get update -q && apt-get install -y rustup clang && rustup default stable
+
+WORKDIR /src
+ENV CARGO_TARGET_DIR /src/target
+CMD [ "/bin/bash", "regenerate_bindings.sh" ]

--- a/cryptoki-sys/README.md
+++ b/cryptoki-sys/README.md
@@ -20,4 +20,22 @@ available, feel free to raise a Pull Request to add it or to use build-time
 generation of bindings. All the committed bindings **MUST** be generated from
 the library version found under the `vendor` submodule.
 
+## Generate bindings in container
+
+To simplify generating bindings, we provide a simple container that ca be
+executed regardless of the operating system in use from the `cryptoki-sys`
+directory.
+
+To generate the bindings in container, just build the container from the
+`Containerfile` in this directory:
+```
+$ podman build -t rust-cryptoki .
+```
+And then run it with the current working directory mounted in the container:
+```
+$ podman run -v $PWD:/src:z rust-cryptoki
+```
+It will download all the rust dependencies and regenerate all the binding
+tiplets.
+
 *Copyright 2021 Contributors to the Parsec project.*


### PR DESCRIPTION
I ended up regenerating the bindings over the last couple of months more times than I would like and given that I do not have Ubuntu, I had to do that in containers, every time figuring out how to do that. This time, I wrote a simple containerfile, which I am dropping here. I do not know if it might be useful for anyone else, but if so, I would be happy to incorporate it. Not sure if in this form or in this place, but I am open for suggestions where it would be better placed.