### PR TITLE
Add pub unsafe accessors for object/session handles and ObjectHandle new

### DIFF
--- a/cryptoki/src/object.rs
+++ b/cryptoki/src/object.rs
@@ -1193,7 +1193,15 @@ impl ObjectHandle {
         ObjectHandle { handle }
     }
 
-    pub(crate) fn handle(&self) -> CK_OBJECT_HANDLE {
+    /// Create a new object handle from a raw handle.
+    /// # Safety
+    /// Considered unsafe due to ability for client to arbitrarily create object handles.
+    pub unsafe fn new_from_raw(handle: CK_OBJECT_HANDLE) -> Self {
+        ObjectHandle { handle }
+    }
+
+    /// Get the raw handle of the object.
+    pub fn handle(&self) -> CK_OBJECT_HANDLE {
         self.handle
     }
 }

--- a/cryptoki/src/session/mod.rs
+++ b/cryptoki/src/session/mod.rs
@@ -78,7 +78,8 @@ impl Session {
     /// This will be called on drop as well.
     pub fn close(self) {}
 
-    pub(crate) fn handle(&self) -> CK_SESSION_HANDLE {
+    /// Get the raw handle of the session.
+    pub fn handle(&self) -> CK_SESSION_HANDLE {
         self.handle
     }
 


### PR DESCRIPTION
As detailed in this [issue](https://github.com/parallaxsecond/rust-cryptoki/issues/316), in order to allow for vendor extensions to the standard, raw session/object handles need to be accessible outside of the crate. Creating new methods marked `unsafe` was the preferred way to allow this extension.

- adds `new_from_raw` method to ObjectHandle to allow creation
- adds `raw_handle` to ObjectHandle to get the underlying handle
- adds `raw_handle` to Session to get the underlying handle