### PR TITLE
Don't tie Session's lifetime to the Pkcs11 object.

### DIFF
--- a/cryptoki/src/context/session_management.rs
+++ b/cryptoki/src/context/session_management.rs
@@ -13,7 +13,7 @@ use super::Function;
 
 impl Pkcs11 {
     #[inline(always)]
-    fn open_session(&self, slot_id: Slot, read_write: bool) -> Result<Session<'_>> {
+    fn open_session(&self, slot_id: Slot, read_write: bool) -> Result<Session> {
         let mut session_handle = 0;
 
         let flags = if read_write {
@@ -33,7 +33,7 @@ impl Pkcs11 {
             .into_result(Function::OpenSession)?;
         }
 
-        Ok(Session::new(session_handle, self))
+        Ok(Session::new(session_handle, self.clone()))
     }
 
     /// Open a new Read-Only session
@@ -62,14 +62,14 @@ impl Pkcs11 {
     /// let session = client.open_ro_session(slot)?;
     /// # let _ = session; Ok(()) }
     /// ```
-    pub fn open_ro_session(&self, slot_id: Slot) -> Result<Session<'_>> {
+    pub fn open_ro_session(&self, slot_id: Slot) -> Result<Session> {
         self.open_session(slot_id, false)
     }
 
     /// Open a new Read/Write session
     ///
     /// Note: No callback is set when opening the session.
-    pub fn open_rw_session(&self, slot_id: Slot) -> Result<Session<'_>> {
+    pub fn open_rw_session(&self, slot_id: Slot) -> Result<Session> {
         self.open_session(slot_id, true)
     }
 }

--- a/cryptoki/src/session/decryption.rs
+++ b/cryptoki/src/session/decryption.rs
@@ -10,7 +10,7 @@ use crate::session::Session;
 use cryptoki_sys::*;
 use std::convert::TryInto;
 
-impl Session<'_> {
+impl Session {
     /// Single-part decryption operation
     pub fn decrypt(
         &self,

--- a/cryptoki/src/session/digesting.rs
+++ b/cryptoki/src/session/digesting.rs
@@ -10,7 +10,7 @@ use crate::session::Session;
 use cryptoki_sys::*;
 use std::convert::TryInto;
 
-impl Session<'_> {
+impl Session {
     /// Single-part digesting operation
     pub fn digest(&self, m: &Mechanism, data: &[u8]) -> Result<Vec<u8>> {
         let mut mechanism: CK_MECHANISM = m.into();

--- a/cryptoki/src/session/encapsulation.rs
+++ b/cryptoki/src/session/encapsulation.rs
@@ -10,7 +10,7 @@ use crate::session::Session;
 use cryptoki_sys::*;
 use std::convert::TryInto;
 
-impl Session<'_> {
+impl Session {
     /// Encapsulate key
     pub fn encapsulate_key(
         &self,

--- a/cryptoki/src/session/encryption.rs
+++ b/cryptoki/src/session/encryption.rs
@@ -10,7 +10,7 @@ use crate::session::Session;
 use cryptoki_sys::*;
 use std::convert::TryInto;
 
-impl Session<'_> {
+impl Session {
     /// Single-part encryption operation
     pub fn encrypt(
         &self,

--- a/cryptoki/src/session/key_management.rs
+++ b/cryptoki/src/session/key_management.rs
@@ -10,7 +10,7 @@ use crate::session::Session;
 use cryptoki_sys::{CK_ATTRIBUTE, CK_MECHANISM, CK_MECHANISM_PTR};
 use std::convert::TryInto;
 
-impl Session<'_> {
+impl Session {
     /// Generate a secret key
     pub fn generate_key(
         &self,

--- a/cryptoki/src/session/message_decryption.rs
+++ b/cryptoki/src/session/message_decryption.rs
@@ -10,7 +10,7 @@ use crate::session::Session;
 use cryptoki_sys::*;
 use std::convert::TryInto;
 
-impl Session<'_> {
+impl Session {
     /// Prepare a session for one or more Message-based decryption using the same mechanism and key
     pub fn message_decrypt_init(&self, mechanism: &Mechanism, key: ObjectHandle) -> Result<()> {
         let mut mechanism: CK_MECHANISM = mechanism.into();

--- a/cryptoki/src/session/message_encryption.rs
+++ b/cryptoki/src/session/message_encryption.rs
@@ -10,7 +10,7 @@ use crate::session::Session;
 use cryptoki_sys::*;
 use std::convert::TryInto;
 
-impl Session<'_> {
+impl Session {
     /// Prepare a session for one or more Message-based encryption using the same mechanism and key
     pub fn message_encrypt_init(&self, mechanism: &Mechanism, key: ObjectHandle) -> Result<()> {
         let mut mechanism: CK_MECHANISM = mechanism.into();

--- a/cryptoki/src/session/mod.rs
+++ b/cryptoki/src/session/mod.rs
@@ -35,33 +35,33 @@ pub use validation::ValidationFlagsType;
 /// threads. A Session needs to be created in its own thread or to be passed by ownership to
 /// another thread.
 #[derive(Debug)]
-pub struct Session<'a> {
+pub struct Session {
     handle: CK_SESSION_HANDLE,
-    client: &'a Pkcs11,
+    client: Pkcs11,
     // This is not used but to prevent Session to automatically implement Send and Sync
     _guard: PhantomData<*mut u32>,
 }
 
-impl<'a> std::fmt::Display for Session<'a> {
+impl std::fmt::Display for Session {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.handle)
     }
 }
 
-impl<'a> std::fmt::LowerHex for Session<'a> {
+impl std::fmt::LowerHex for Session {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:08x}", self.handle)
     }
 }
 
-impl<'a> std::fmt::UpperHex for Session<'a> {
+impl std::fmt::UpperHex for Session {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:08X}", self.handle)
     }
 }
 
-impl<'a> Session<'a> {
-    pub(crate) fn new(handle: CK_SESSION_HANDLE, client: &'a Pkcs11) -> Self {
+impl Session {
+    pub(crate) fn new(handle: CK_SESSION_HANDLE, client: Pkcs11) -> Self {
         Session {
             handle,
             client,
@@ -70,7 +70,7 @@ impl<'a> Session<'a> {
     }
 }
 
-impl<'a> Session<'a> {
+impl Session {
     /// Close a session
     /// This will be called on drop as well.
     pub fn close(self) -> Result<()> {
@@ -83,7 +83,7 @@ impl<'a> Session<'a> {
     }
 
     pub(crate) fn client(&self) -> &Pkcs11 {
-        self.client
+        &self.client
     }
 }
 

--- a/cryptoki/src/session/object_management.rs
+++ b/cryptoki/src/session/object_management.rs
@@ -78,7 +78,7 @@ const MAX_OBJECT_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) 
 /// ```
 #[derive(Debug)]
 pub struct ObjectHandleIterator<'a> {
-    session: &'a Session<'a>,
+    session: &'a Session,
     object_count: usize,
     index: usize,
     cache: Vec<CK_OBJECT_HANDLE>,
@@ -207,7 +207,7 @@ impl Drop for ObjectHandleIterator<'_> {
     }
 }
 
-impl Session<'_> {
+impl Session {
     /// Iterate over session objects matching a template.
     ///
     /// # Arguments

--- a/cryptoki/src/session/random.rs
+++ b/cryptoki/src/session/random.rs
@@ -7,7 +7,7 @@ use crate::error::{Result, Rv};
 use crate::session::Session;
 use std::convert::TryInto;
 
-impl Session<'_> {
+impl Session {
     /// Generates a random number and sticks it in a slice
     ///
     /// # Arguments

--- a/cryptoki/src/session/session_management.rs
+++ b/cryptoki/src/session/session_management.rs
@@ -14,7 +14,7 @@ use log::error;
 use secrecy::ExposeSecret;
 use std::convert::{TryFrom, TryInto};
 
-impl Drop for Session<'_> {
+impl Drop for Session {
     fn drop(&mut self) {
         match self.close_inner() {
             Err(Error::Pkcs11(RvError::SessionClosed, Function::CloseSession)) => (), // the session has already been closed: ignore.
@@ -26,7 +26,7 @@ impl Drop for Session<'_> {
     }
 }
 
-impl Session<'_> {
+impl Session {
     /// Log a session in.
     ///
     /// # Arguments

--- a/cryptoki/src/session/signing_macing.rs
+++ b/cryptoki/src/session/signing_macing.rs
@@ -10,7 +10,7 @@ use crate::session::Session;
 use cryptoki_sys::*;
 use std::convert::TryInto;
 
-impl Session<'_> {
+impl Session {
     /// Sign data in single-part
     pub fn sign(&self, mechanism: &Mechanism, key: ObjectHandle, data: &[u8]) -> Result<Vec<u8>> {
         let mut mechanism: CK_MECHANISM = mechanism.into();

--- a/cryptoki/src/session/slot_token_management.rs
+++ b/cryptoki/src/session/slot_token_management.rs
@@ -9,7 +9,7 @@ use crate::types::AuthPin;
 use secrecy::ExposeSecret;
 use std::convert::TryInto;
 
-impl Session<'_> {
+impl Session {
     /// Initialize the normal user's pin for a token
     pub fn init_pin(&self, pin: &AuthPin) -> Result<()> {
         unsafe {

--- a/cryptoki/src/session/validation.rs
+++ b/cryptoki/src/session/validation.rs
@@ -46,7 +46,7 @@ impl From<ValidationFlagsType> for CK_SESSION_VALIDATION_FLAGS_TYPE {
     }
 }
 
-impl Session<'_> {
+impl Session {
     /// Get requested validation flags from the session
     ///
     /// The only supported flag as for PKCS#11 3.2 is `ValidationFlagsType::VALIDATION_OK`

--- a/cryptoki/tests/basic.rs
+++ b/cryptoki/tests/basic.rs
@@ -25,7 +25,6 @@ use cryptoki::types::{AuthPin, Ulong};
 use serial_test::serial;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
-use std::sync::Arc;
 use std::thread;
 
 use cryptoki::mechanism::ekdf::AesCbcDeriveParams;
@@ -1595,7 +1594,6 @@ fn login_feast() {
     const SESSIONS: usize = 100;
 
     let (pkcs11, slot) = init_pins();
-    let pkcs11 = Arc::new(pkcs11);
     let mut threads = Vec::new();
 
     for _ in 0..SESSIONS {
@@ -1633,7 +1631,7 @@ fn login_feast() {
         thread.join().unwrap();
     }
 
-    Arc::into_inner(pkcs11).unwrap().finalize().unwrap();
+    pkcs11.finalize().unwrap();
 }
 
 #[test]
@@ -1948,7 +1946,7 @@ fn is_initialized_test() -> TestResult {
 fn test_clone_initialize() -> TestResult {
     use cryptoki::context::CInitializeArgs;
 
-    let pkcs11 = Arc::new(get_pkcs11());
+    let pkcs11 = get_pkcs11();
 
     {
         let clone = pkcs11.clone();
@@ -1971,7 +1969,7 @@ fn test_clone_initialize() -> TestResult {
         }
     }
 
-    Arc::into_inner(pkcs11).unwrap().finalize()?;
+    pkcs11.finalize()?;
 
     Ok(())
 }


### PR DESCRIPTION
This commit effectively reverts
1994987175423b5508a0a2b75ff01d55fef348eb, which made Session take a reference to Pkcs11 and removed the inner Arc.

As discussed in
https://github.com/parallaxsecond/rust-cryptoki/pull/333 , tying a Session object to a Pkcs11 object reference can complicate object management.