### PR TITLE
Accept `TryFrom<CK_MECHANISM_TYPE>` for vendor mechanisms

### DIFF
--- a/cryptoki/src/mechanism/mod.rs
+++ b/cryptoki/src/mechanism/mod.rs
@@ -1019,6 +1019,7 @@ impl TryFrom<CK_MECHANISM_TYPE> for MechanismType {
             CKM_HASH_SLH_DSA_SHA3_384 => Ok(MechanismType::HASH_SLH_DSA_SHA3_384),
             CKM_HASH_SLH_DSA_SHA3_512 => Ok(MechanismType::HASH_SLH_DSA_SHA3_512),
             CKM_HASH_SLH_DSA_SHAKE128 => Ok(MechanismType::HASH_SLH_DSA_SHAKE128),
+            val if val >= CKM_VENDOR_DEFINED => Ok(MechanismType { val }),
             other => {
                 error!("Mechanism type {other} is not supported.");
                 Err(Error::NotSupported)


### PR DESCRIPTION
Hi, we've been using a similar patch downstream in [OpenTitan](https://github.com/lowRISC/opentitan/blob/master/third_party/rust/patches/cryptoki-vendor-defined-mechanism-type.patch) so I wanted to upstream this change.