### PR TITLE
Allow call with null pointer for handle key and template

### DIFF
--- a/cryptoki/src/session/key_management.rs
+++ b/cryptoki/src/session/key_management.rs
@@ -73,24 +73,49 @@ impl Session {
         &self,
         mechanism: &Mechanism,
         base_key: ObjectHandle,
-        template: &[Attribute],
+        template: Option<&[Attribute]>,
     ) -> Result<ObjectHandle> {
         let mut mechanism: CK_MECHANISM = mechanism.into();
-        let mut template: Vec<CK_ATTRIBUTE> = template.iter().map(|attr| attr.into()).collect();
-        let mut handle = 0;
-        unsafe {
-            Rv::from(get_pkcs11!(self.client(), C_DeriveKey)(
-                self.handle(),
-                &mut mechanism as CK_MECHANISM_PTR,
-                base_key.handle(),
-                template.as_mut_ptr(),
-                template.len().try_into()?,
-                &mut handle,
-            ))
-            .into_result(Function::DeriveKey)?;
-        }
+        let template = template.map(|template| {
+            template
+                .iter()
+                .map(|attr| attr.into())
+                .collect::<Vec<CK_ATTRIBUTE>>()
+        });
 
-        Ok(ObjectHandle::new(handle))
+        match template {
+            Some(template) => {
+                let mut template = template;
+                let mut handle = 0;
+
+                unsafe {
+                    Rv::from(get_pkcs11!(self.client(), C_DeriveKey)(
+                        self.handle(),
+                        &mut mechanism as CK_MECHANISM_PTR,
+                        base_key.handle(),
+                        template.as_mut_ptr(),
+                        template.len().try_into()?,
+                        &mut handle,
+                    ))
+                    .into_result(Function::DeriveKey)?;
+                }
+
+                Ok(ObjectHandle::new(handle))
+            }
+            None => unsafe {
+                Rv::from(get_pkcs11!(self.client(), C_DeriveKey)(
+                    self.handle(),
+                    &mut mechanism as CK_MECHANISM_PTR,
+                    base_key.handle(),
+                    std::ptr::null_mut(),
+                    0,
+                    std::ptr::null_mut(),
+                ))
+                .into_result(Function::DeriveKey)?;
+
+                Ok(ObjectHandle::new(0))
+            },
+        }
     }
 
     /// Wrap key


### PR DESCRIPTION
Some calls to Thales Luna HSMs allows the following call of `C_DeriveKey`:

```cpp
const CK_RV rv = C_DeriveKey( session, &mech, parent, NULL, 0, NULL );
```

One example is when trying to do bip32 derivation using `CKM_BIP32_CHILD_DERIVE` [CK_BIP32_CHILD_DERIVE_PARAMS](https://thalesdocs.com/gphsm/luna/7/docs/network/Content/sdk/extensions/BIP32.htm). The call works as follows:
- `pTemplate` and `phKey` are null pointers
- private and public key handles are found in  `CK_BIP32_CHILD_DERIVE_PARAMS.hPublicKey` and `CK_BIP32_CHILD_DERIVE_PARAMS.hPrivateKey`

At the moment this is not expressable by the `cryptoki` crate so I was thinking it would be nice to allow it.

I tested this against a Thales Luna Network HSM

If there is interest in this, I can work on making the tests pass as well, which is trivial

# Downsides

1. It breaks the API of `derive_key`
2. When allowing the above call, the returned handle contains `0` as value so the return type should be changed as well to better reflect user's intention